### PR TITLE
Refactor imports to use absolute package-style paths

### DIFF
--- a/JanusAI/__main__.py
+++ b/JanusAI/__main__.py
@@ -8,7 +8,7 @@ Supports both physics discovery and AI interpretability research.
 import sys
 import logging
 from pathlib import Path
-from JanusAI.cli.main import cli
+from janus_ai.cli.main import cli
 
 
 # Add project root to path for development
@@ -16,7 +16,7 @@ project_root = Path(__file__).parent.parent
 if str(project_root) not in sys.path:
     sys.path.insert(0, str(project_root))
 
-from JanusAI.cli.main import cli
+from janus_ai.cli.main import cli
 
 if __name__ == "__main__":
     # Configure logging

--- a/JanusAI/ai_interpretability/__init__.py
+++ b/JanusAI/ai_interpretability/__init__.py
@@ -12,22 +12,22 @@ VERSION = "0.1.0" # Example version
 # For symbols within the ai_interpretability package, relative imports are fine.
 # For symbols outside, absolute imports are used.
 
-from JanusAI.ai_interpretability.grammars import NeuralGrammar
-from JanusAI.environments.ai_interpretability.neural_net_env import (
+from janus_ai.ai_interpretability.grammars import NeuralGrammar
+from janus_ai.environments.ai_interpretability.neural_net_env import (
     AIBehaviorData,
     AIInterpretabilityEnv,
     LocalInterpretabilityEnv,
     SymbolicDiscoveryEnv,
     AIDiscoveryEnv
 )
-from JanusAI.environments.ai_interpretability.transformer_env import TransformerInterpretabilityEnv # Assuming it's here
-from JanusAI.ai_interpretability.rewards import InterpretabilityReward, FidelityRewardCalculator
-from JanusAI.ai_interpretability.interpreters import AILawDiscovery
-from JanusAI.ai_interpretability.symbolic.expression_parser import ExpressionParser
-from JanusAI.environments.ai_interpretability.model_hooks import ModelHookManager, register_hooks_for_layers
-from JanusAI.utils.visualization.plotting import ExperimentVisualizer
+from janus_ai.environments.ai_interpretability.transformer_env import TransformerInterpretabilityEnv # Assuming it's here
+from janus_ai.ai_interpretability.rewards import InterpretabilityReward, FidelityRewardCalculator
+from janus_ai.ai_interpretability.interpreters import AILawDiscovery
+from janus_ai.ai_interpretability.symbolic.expression_parser import ExpressionParser
+from janus_ai.environments.ai_interpretability.model_hooks import ModelHookManager, register_hooks_for_layers
+from janus_ai.utils.visualization.plotting import ExperimentVisualizer
 # 'math_utils' was too vague and its previous import '.utils' was incorrect.
-# Users should import specific math utilities directly from JanusAI.utils.math
+# Users should import specific math utilities directly from janus_ai.utils.math
 
 __all__ = [
     "NeuralGrammar",

--- a/JanusAI/ai_interpretability/evaluation/consistency.py
+++ b/JanusAI/ai_interpretability/evaluation/consistency.py
@@ -15,16 +15,16 @@ from typing import Any, Dict, List, Optional, Union
 from dataclasses import dataclass, field
 
 # Import core components
-from JanusAI.core.expressions.expression import Expression, Variable
-from JanusAI.core.expressions.symbolic_math import evaluate_expression_on_data, are_expressions_equivalent_sympy # For comparison and evaluation
-from JanusAI.utils.math.operations import calculate_expression_complexity # For simplicity metrics
+from janus_ai.core.expressions.expression import Expression, Variable
+from janus_ai.core.expressions.symbolic_math import evaluate_expression_on_data, are_expressions_equivalent_sympy # For comparison and evaluation
+from janus_ai.utils.math.operations import calculate_expression_complexity # For simplicity metrics
 
 # Import the new ModelFidelityEvaluator for consistency checks
-from JanusAI.ai_interpretability.evaluation.fidelity import ModelFidelityEvaluator
+from janus_ai.ai_interpretability.evaluation.fidelity import ModelFidelityEvaluator
 
 # Placeholder for AI model classes
 try:
-    from JanusAI.ml.networks.hypothesis_net import HypothesisNet, AIHypothesisNet
+    from janus_ai.ml.networks.hypothesis_net import HypothesisNet, AIHypothesisNet
 except ImportError:
     print("Warning: HypothesisNet or AIHypothesisNet not found for type hinting in consistency.py. Using generic nn.Module.")
     HypothesisNet = nn.Module
@@ -268,10 +268,10 @@ class InterpretabilityEvaluator:
 if __name__ == "__main__":
     # Mock symbolic_math, Expression, Variable, HypothesisNet for testing
     try:
-        from JanusAI.core.expressions.expression import Expression as RealExpression, Variable as RealVariable
-        from JanusAI.core.expressions.symbolic_math import evaluate_expression_on_data as real_eval_expr_on_data
-        from JanusAI.core.expressions.symbolic_math import are_expressions_equivalent_sympy as real_are_eq_sympy
-        from JanusAI.utils.math.operations import calculate_expression_complexity as real_calc_expr_comp
+        from janus_ai.core.expressions.expression import Expression as RealExpression, Variable as RealVariable
+        from janus_ai.core.expressions.symbolic_math import evaluate_expression_on_data as real_eval_expr_on_data
+        from janus_ai.core.expressions.symbolic_math import are_expressions_equivalent_sympy as real_are_eq_sympy
+        from janus_ai.utils.math.operations import calculate_expression_complexity as real_calc_expr_comp
     except ImportError:
         print("Using mock dependencies for consistency.py test.")
         @dataclass(eq=True, frozen=False)

--- a/JanusAI/ai_interpretability/grammars/__init__.py
+++ b/JanusAI/ai_interpretability/grammars/__init__.py
@@ -1,7 +1,7 @@
 # Init file for grammars module
-from .neural_grammar import NeuralGrammar
-# from .nlp_grammar import NlpGrammar # Placeholder, uncomment when class exists
-# from .vision_grammar import VisionGrammar # Placeholder, uncomment when class exists
+from janus_ai.ai_interpretability.grammars.neural_grammar import NeuralGrammar
+# from janus_ai.ai_interpretability.grammars.nlp_grammar import NlpGrammar # Placeholder, uncomment when class exists
+# from janus_ai.ai_interpretability.grammars.vision_grammar import VisionGrammar # Placeholder, uncomment when class exists
 
 __all__ = [
     "NeuralGrammar",

--- a/JanusAI/ai_interpretability/grammars/ai_grammar.py
+++ b/JanusAI/ai_interpretability/grammars/ai_grammar.py
@@ -2,8 +2,8 @@ import numpy as np
 import sympy as sp
 from typing import List, Dict, Any, Callable
 
-from JanusAI.core.grammar.base_grammar import ProgressiveGrammar, Primitive
-from JanusAI.core.expressions.expression import Expression, Variable
+from janus_ai.core.grammar.base_grammar import ProgressiveGrammar, Primitive
+from janus_ai.core.expressions.expression import Expression, Variable
 
 # Helper function for softmax, assuming it might be used by Attention node
 def softmax(x: np.ndarray, axis: int = -1) -> np.ndarray:

--- a/JanusAI/ai_interpretability/interpreters/__init__.py
+++ b/JanusAI/ai_interpretability/interpreters/__init__.py
@@ -1,7 +1,7 @@
 # Init file for interpreters module
-from .base_interpreter import AILawDiscovery
-# from .classification_interpreter import ClassificationInterpreter # Placeholder
-# from .attention_interpreter import AttentionInterpreter # Placeholder
+from janus_ai.ai_interpretability.interpreters.base_interpreter import AILawDiscovery
+# from janus_ai.ai_interpretability.interpreters.classification_interpreter import ClassificationInterpreter # Placeholder
+# from janus_ai.ai_interpretability.interpreters.attention_interpreter import AttentionInterpreter # Placeholder
 
 __all__ = [
     "AILawDiscovery",

--- a/JanusAI/ai_interpretability/interpreters/base_interpreter.py
+++ b/JanusAI/ai_interpretability/interpreters/base_interpreter.py
@@ -7,23 +7,23 @@ from typing import Dict, List, Tuple, Optional, Any
 # AIBehaviorData, HypothesisNet, PPOTrainer are accessible.
 # These imports will need to be relative to their new locations.
 
-# from ...core.grammar import Expression # If Expression is in a core module
-# from ..grammars.neural_grammar import NeuralGrammar
-# from ..environments.neural_net_env import AIInterpretabilityEnv, LocalInterpretabilityEnv, AIBehaviorData
-# from ...training.ppo_trainer import PPOTrainer # Assuming ppo_trainer might be structured elsewhere
-# from ...models.hypothesis_network import HypothesisNet # Assuming hypothesis_network might be structured elsewhere
+# from janus_ai.core.grammar import Expression # If Expression is in a core module
+# from janus_ai.ai_interpretability.grammars.neural_grammar import NeuralGrammar
+# from janus_ai.ai_interpretability.environments.neural_net_env import AIInterpretabilityEnv, LocalInterpretabilityEnv, AIBehaviorData
+# from janus_ai.training.ppo_trainer import PPOTrainer # Assuming ppo_trainer might be structured elsewhere
+# from janus_ai.ml.networks.hypothesis_network import HypothesisNet # Assuming hypothesis_network might be structured elsewhere
 
 # TEMPORARY: Using direct/potentially adjusted imports.
 # These will be fixed in the "Adjust Imports" step.
-from JanusAI.core.grammar.expression import Expression # Updated import
-from JanusAI.ai_interpretability.grammars.neural_grammar import NeuralGrammar
-from JanusAI.environments.ai_interpretability.neural_net_env import AIInterpretabilityEnv, LocalInterpretabilityEnv, AIBehaviorData
+from janus_ai.core.grammar.expression import Expression # Updated import
+from janus_ai.ai_interpretability.grammars.neural_grammar import NeuralGrammar
+from janus_ai.environments.ai_interpretability.neural_net_env import AIInterpretabilityEnv, LocalInterpretabilityEnv, AIBehaviorData
 
 # The following imports are for components that might not be part of this specific refactoring's scope
 # but were present in the original file. Their final location will determine the correct import path.
 # If they are not found, these lines will cause errors later, highlighting unresolved dependencies.
 try:
-    from JanusAI.ml.networks.hypothesis_net import HypothesisNet, PPOTrainer
+    from janus_ai.ml.networks.hypothesis_net import HypothesisNet, PPOTrainer
 except ImportError:
     # Provide dummy classes if not found, to allow rest of the file to be processed.
     # This is a temporary measure for the refactoring step.

--- a/JanusAI/ai_interpretability/rewards/__init__.py
+++ b/JanusAI/ai_interpretability/rewards/__init__.py
@@ -1,6 +1,6 @@
 # Init file for rewards module
-from .interpretability_reward import InterpretabilityReward
-from .fidelity_reward import FidelityRewardCalculator
+from janus_ai.ai_interpretability.rewards.interpretability_reward import InterpretabilityReward
+from janus_ai.ai_interpretability.rewards.fidelity_reward import FidelityRewardCalculator
 
 __all__ = [
     "InterpretabilityReward",

--- a/JanusAI/ai_interpretability/rewards/interpretability_reward.py
+++ b/JanusAI/ai_interpretability/rewards/interpretability_reward.py
@@ -2,7 +2,7 @@ from typing import Any, Dict
 import numpy as np
 import torch
 
-from JanusAI.ai_interpretability.evaluation.fidelity import ModelFidelityEvaluator
+from janus_ai.ai_interpretability.evaluation.fidelity import ModelFidelityEvaluator
 
 class InterpretabilityReward:
     # existing class content...

--- a/JanusAI/ai_interpretability/symbolic/neural_grammar.py
+++ b/JanusAI/ai_interpretability/symbolic/neural_grammar.py
@@ -2,13 +2,13 @@
 
 # Assuming ProgressiveGrammar, Expression, Variable are in a place accessible by this path
 # If they are part of the old root structure and not yet moved:
-# from janus.core.grammar import ProgressiveGrammar
-# from janus.core.expression import Expression, Variable
+# from janus_ai.core.grammar import ProgressiveGrammar
+# from janus_ai.core.expression import Expression, Variable
 # If they are meant to be part of janus core or a shared module:
-# from ....shared import ProgressiveGrammar, Expression, Variable
+# from janus_ai.shared import ProgressiveGrammar, Expression, Variable # Assuming a shared module might exist
 # For now, using placeholder relative imports if they are also being moved into janus structure
-# from ...core.grammar import ProgressiveGrammar, Expression, Variable
-# Based on file listing, `grammar.py` is now in `janus/core`.
+# from janus_ai.core.grammar import ProgressiveGrammar, Expression, Variable
+# Based on file listing, `grammar.py` is now in `janus_ai/core`.
 # So, the import needs to be adjusted once its final location is decided.
 # For this refactoring, we'll assume it will be findable from the new structure.
 # A common pattern is to have a `core` or `common` module at `janus/` level.
@@ -16,8 +16,8 @@
 
 import sympy as sp
 from typing import List, Dict, Any, Optional
-from JanusAI.core.grammar.progressive_grammar import ProgressiveGrammar # Updated import
-from JanusAI.core.expressions.expression import Expression, Variable
+from janus_ai.core.grammar.progressive_grammar import ProgressiveGrammar # Updated import
+from janus_ai.core.expressions.expression import Expression, Variable
 
 class AIGrammar(ProgressiveGrammar):
     """

--- a/JanusAI/cli/commands/benchmark.py
+++ b/JanusAI/cli/commands/benchmark.py
@@ -6,8 +6,8 @@ import logging
 from typing import List, Dict, Any
 import pandas as pd
 
-from JanusAI.experiments.benchmarks import BenchmarkSuite
-from JanusAI.utils.visualization import plot_benchmark_results
+from janus_ai.experiments.benchmarks import BenchmarkSuite
+from janus_ai.utils.visualization import plot_benchmark_results
 
 logger = logging.getLogger(__name__)
 

--- a/JanusAI/cli/commands/discover.py
+++ b/JanusAI/cli/commands/discover.py
@@ -8,9 +8,9 @@ import logging
 from pathlib import Path
 from typing import Optional, Dict, Any
 
-from JanusAI.experiments.registry import ExperimentRegistry
-from JanusAI.config.models import DiscoveryConfig
-from JanusAI.utils.io import save_results
+from janus_ai.experiments.registry import ExperimentRegistry
+from janus_ai.config.models import DiscoveryConfig
+from janus_ai.utils.io import save_results
 
 logger = logging.getLogger(__name__)
 

--- a/JanusAI/cli/commands/train.py
+++ b/JanusAI/cli/commands/train.py
@@ -6,8 +6,8 @@ import click
 import logging
 from pathlib import Path
 
-from JanusAI.training.trainer import UnifiedTrainer
-from JanusAI.config.loader import load_config
+from janus_ai.training.trainer import UnifiedTrainer
+from janus_ai.config.loader import load_config
 
 logger = logging.getLogger(__name__)
 

--- a/JanusAI/cli/commands/visualize.py
+++ b/JanusAI/cli/commands/visualize.py
@@ -6,7 +6,7 @@ import logging # Added for more consistent logging
 
 # Attempt to import ExperimentVisualizer
 try:
-    from JanusAI.utils.visualization.plotting import ExperimentVisualizer
+    from janus_ai.utils.visualization.plotting import ExperimentVisualizer
     HAS_VISUALIZER = True
 except ImportError:
     HAS_VISUALIZER = False

--- a/JanusAI/cli/main.py
+++ b/JanusAI/cli/main.py
@@ -1,8 +1,8 @@
 import click
-from JanusAI.cli.commands.train import train
-from JanusAI.cli.commands.evaluate import evaluate
-from JanusAI.cli.commands.discover import discover
-from JanusAI.cli.commands.visualize import visualize
+from janus_ai.cli.commands.train import train
+from janus_ai.cli.commands.evaluate import evaluate
+from janus_ai.cli.commands.discover import discover
+from janus_ai.cli.commands.visualize import visualize
 
 # janus/cli/main.py
 """Main CLI interface for Janus framework."""
@@ -12,9 +12,9 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-from JanusAI.cli.commands import discover, train, evaluate, visualize, benchmark
-from JanusAI.config.loader import load_config
-from JanusAI.utils.logging import setup_logging
+from janus_ai.cli.commands import discover, train, evaluate, visualize, benchmark
+from janus_ai.config.loader import load_config
+from janus_ai.utils.logging import setup_logging
 
 logger = logging.getLogger(__name__)
 

--- a/JanusAI/config/loader.py
+++ b/JanusAI/config/loader.py
@@ -3,7 +3,7 @@ import yaml
 import os
 from pathlib import Path
 
-from .models import JanusConfig # Assuming JanusConfig might be a common return type or used internally
+from janus_ai.config.models import JanusConfig # Assuming JanusConfig might be a common return type or used internally
 
 # Define a more specific type for configuration dictionaries if possible
 ConfigDict = Dict[str, Any]

--- a/JanusAI/core/expressions/__init__.py
+++ b/JanusAI/core/expressions/__init__.py
@@ -1,2 +1,2 @@
-from .expression import Expression, Variable
-from .symbolic_math import SymbolicMath
+from janus_ai.core.expressions.expression import Expression, Variable
+from janus_ai.core.expressions.symbolic_math import SymbolicMath

--- a/JanusAI/core/expressions/test_expression.py
+++ b/JanusAI/core/expressions/test_expression.py
@@ -8,8 +8,8 @@ import numpy as np
 import sympy as sp
 from unittest.mock import MagicMock, patch
 
-from JanusAI.core.expressions.expression import Expression, Variable
-from JanusAI.core.expressions.symbolic_math import evaluate_expression_on_data
+from janus_ai.core.expressions.expression import Expression, Variable
+from janus_ai.core.expressions.symbolic_math import evaluate_expression_on_data
 
 
 class TestVariable:

--- a/JanusAI/core/grammar/__init__.py
+++ b/JanusAI/core/grammar/__init__.py
@@ -1,3 +1,3 @@
-from .base_grammar import ContextFreeGrammar, CFGRule
-from .progressive_grammar import ProgressiveGrammar
-from .ai_grammar import AIGrammar
+from janus_ai.core.grammar.base_grammar import ContextFreeGrammar, CFGRule
+from janus_ai.core.grammar.progressive_grammar import ProgressiveGrammar
+from janus_ai.core.grammar.ai_grammar import AIGrammar

--- a/JanusAI/core/grammar/advanced_ai_grammar.py
+++ b/JanusAI/core/grammar/advanced_ai_grammar.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, List, Optional, Callable, Union
 from dataclasses import dataclass
 
 # Import base grammar
-from JanusAI.core.grammar.base_grammar import ProgressiveGrammar
+from janus_ai.core.grammar.base_grammar import ProgressiveGrammar
 
 
 class AttentionPrimitives:

--- a/JanusAI/core/grammar/ai_grammar.py
+++ b/JanusAI/core/grammar/ai_grammar.py
@@ -7,8 +7,8 @@ import torch # Added for _attention_op, _embedding_op
 from typing import Dict, List, Tuple, Optional, Set, Any, Union # Added Union
 import logging # Added for _validate_expression
 
-from .progressive_grammar import ProgressiveGrammar
-from JanusAI.core.expressions.expression import Expression, Variable # Variable is used in _validate_expression
+from janus_ai.core.grammar.progressive_grammar import ProgressiveGrammar
+from janus_ai.core.expressions.expression import Expression, Variable # Variable is used in _validate_expression
 
 class AIGrammar(ProgressiveGrammar):
     """

--- a/JanusAI/core/grammar/base_grammar.py
+++ b/JanusAI/core/grammar/base_grammar.py
@@ -12,18 +12,18 @@ to maintain backward compatibility.
 import warnings
 
 # Re-export classes from their new locations
-from .cfg import CFGRule, ContextFreeGrammar
-from .denoiser import NoisyObservationProcessor
-from .progressive_grammar import ProgressiveGrammar
-from .ai_grammar import AIGrammar
+from janus_ai.core.grammar.cfg import CFGRule, ContextFreeGrammar
+from janus_ai.core.grammar.denoiser import NoisyObservationProcessor
+from janus_ai.core.grammar.progressive_grammar import ProgressiveGrammar
+from janus_ai.core.grammar.ai_grammar import AIGrammar
 
 # It's also common to re-export key components from sibling modules if they were
 # previously accessible via this base module, e.g., Expression and Variable.
 # Assuming Expression and Variable were commonly imported alongside grammar classes:
-from .expression import Expression, Variable
+from janus_ai.core.expressions.expression import Expression, Variable # Adjusted path
 
 # And the TargetType alias if it was considered part of this module's public API
-from .cfg import TargetType # TargetType is defined and used in cfg.py
+from janus_ai.core.grammar.cfg import TargetType # TargetType is defined and used in cfg.py
 
 warnings.filterwarnings('ignore')
 

--- a/JanusAI/core/grammar/progressive_grammar.py
+++ b/JanusAI/core/grammar/progressive_grammar.py
@@ -11,9 +11,9 @@ from sklearn.decomposition import FastICA
 import warnings
 
 # Imports that will be needed from the new module structure
-from JanusAI.core.expressions.expression import Expression, Variable
-from .denoiser import NoisyObservationProcessor
-from .cfg import ContextFreeGrammar, CFGRule # CFGRule is used by ProgressiveGrammar
+from janus_ai.core.expressions.expression import Expression, Variable
+from janus_ai.core.grammar.denoiser import NoisyObservationProcessor
+from janus_ai.core.grammar.cfg import ContextFreeGrammar, CFGRule # CFGRule is used by ProgressiveGrammar
 
 warnings.filterwarnings('ignore')
 

--- a/JanusAI/core/grammar/test_base_grammar.py
+++ b/JanusAI/core/grammar/test_base_grammar.py
@@ -10,9 +10,9 @@ from unittest.mock import MagicMock, patch, PropertyMock
 from sklearn.decomposition import FastICA
 
 # BaseGrammar is now ProgressiveGrammar for the purpose of these tests
-from JanusAI.core.grammar.progressive_grammar import ProgressiveGrammar # Updated, BaseGrammar replaced
-from JanusAI.core.grammar.denoiser import NoisyObservationProcessor # Updated
-from JanusAI.core.expressions.expression import Expression, Variable
+from janus_ai.core.grammar.progressive_grammar import ProgressiveGrammar # Updated, BaseGrammar replaced
+from janus_ai.core.grammar.denoiser import NoisyObservationProcessor # Updated
+from janus_ai.core.expressions.expression import Expression, Variable
 
 
 class TestBaseGrammar: # This class name might be misleading now.

--- a/JanusAI/core/search/__init__.py
+++ b/JanusAI/core/search/__init__.py
@@ -22,7 +22,7 @@ Main Components:
 """
 
 # Import main classes and functions for easy access
-from JanusAI.core.search.config import (
+from janus_ai.core.search.config import (
     GAConfig,
     PerformanceConfig,  # Deprecated but kept for compatibility
     ExpressionConfig,
@@ -35,7 +35,7 @@ from JanusAI.core.search.config import (
     create_exploratory_expression_config
 )
 
-from JanusAI.core.search.stats import (
+from janus_ai.core.search.stats import (
     StatsTracker,
     SearchStats,
     GenerationStats,
@@ -43,7 +43,7 @@ from JanusAI.core.search.stats import (
     analyze_search_run
 )
 
-from JanusAI.core.search.selection import (
+from janus_ai.core.search.selection import (
     SelectionStrategy,
     TournamentSelection,
     RouletteWheelSelection,
@@ -55,7 +55,7 @@ from JanusAI.core.search.selection import (
     analyze_selection_pressure
 )
 
-from JanusAI.core.search.operators import (
+from janus_ai.core.search.operators import (
     ExpressionGenerator,
     CrossoverOperator,
     MutationOperator,
@@ -72,7 +72,7 @@ from JanusAI.core.search.operators import (
 
 # Import main regressor from the parent module to maintain clean imports
 # This allows: from janus.core.search import SymbolicRegressor
-from JanusAI.physics.algorithms.genetic import (
+from janus_ai.physics.algorithms.genetic import (
     SymbolicRegressor,
     FitnessCache,
     create_regressor_from_config,

--- a/JanusAI/core/search/operators.py
+++ b/JanusAI/core/search/operators.py
@@ -17,10 +17,10 @@ import logging
 if TYPE_CHECKING:
     from janus.core.search.config import ExpressionConfig
 
-from JanusAI.core.grammar.progressive_grammar import ProgressiveGrammar as BaseGrammar # Updated import
-from JanusAI.core.expressions.expression import Expression, Variable
-from JanusAI.core.expressions.symbolic_math import get_expression_complexity, expression_to_string
-from JanusAI.utils.exceptions import GrammarError, OptimizationError
+from janus_ai.core.grammar.progressive_grammar import ProgressiveGrammar as BaseGrammar # Updated import
+from janus_ai.core.expressions.expression import Expression, Variable
+from janus_ai.core.expressions.symbolic_math import get_expression_complexity, expression_to_string
+from janus_ai.utils.exceptions import GrammarError, OptimizationError
 
 
 class ExpressionGenerator:

--- a/JanusAI/core/search/selection.py
+++ b/JanusAI/core/search/selection.py
@@ -12,8 +12,8 @@ from abc import ABC, abstractmethod
 import random
 import logging
 
-from JanusAI.core.expressions.expression import Expression
-from JanusAI.utils.exceptions import UnsupportedOperationError, OptimizationError
+from janus_ai.core.expressions.expression import Expression
+from janus_ai.utils.exceptions import UnsupportedOperationError, OptimizationError
 
 
 class SelectionStrategy(ABC):

--- a/JanusAI/environments/ai_interpretability/neural_net_env.py
+++ b/JanusAI/environments/ai_interpretability/neural_net_env.py
@@ -12,9 +12,9 @@ from typing import Dict, List, Tuple, Optional, Any, Callable
 from dataclasses import dataclass
 import sympy as sp
 
-from JanusAI.core.expressions.expression import Expression, Variable
-from JanusAI.environments.base.symbolic_env import SymbolicDiscoveryEnv
-from JanusAI.ai_interpretability.grammars.neural_grammar import NeuralGrammar
+from janus_ai.core.expressions.expression import Expression, Variable
+from janus_ai.environments.base.symbolic_env import SymbolicDiscoveryEnv
+from janus_ai.ai_interpretability.grammars.neural_grammar import NeuralGrammar
 
 
 @dataclass
@@ -232,7 +232,7 @@ class AIInterpretabilityEnv(SymbolicDiscoveryEnv):
     
     def _evaluate_expression_on_data(self, expression: Expression) -> np.ndarray:
         """Evaluate expression on the environment's data."""
-        from JanusAI.core.expressions.symbolic_math import evaluate_expression_on_data
+        from janus_ai.core.expressions.symbolic_math import evaluate_expression_on_data
         
         return evaluate_expression_on_data(
             str(expression),

--- a/JanusAI/environments/ai_interpretability/transformer_env.py
+++ b/JanusAI/environments/ai_interpretability/transformer_env.py
@@ -11,11 +11,11 @@ import torch
 from typing import Dict, List, Optional, Any
 from dataclasses import dataclass
 
-from JanusAI.environments.ai_interpretability.neural_net_env import (
+from janus_ai.environments.ai_interpretability.neural_net_env import (
     AIInterpretabilityEnv, AIBehaviorData
 )
-from JanusAI.core.expressions.expression import Variable
-from JanusAI.ai_interpretability.grammars.transformer_grammar import TransformerGrammar
+from janus_ai.core.expressions.expression import Variable
+from janus_ai.ai_interpretability.grammars.transformer_grammar import TransformerGrammar
 
 
 @dataclass

--- a/JanusAI/environments/base/physics_env.py
+++ b/JanusAI/environments/base/physics_env.py
@@ -16,16 +16,16 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from dataclasses import dataclass, field
 
 # Import base symbolic environment
-from JanusAI.environments.base.symbolic_env import SymbolicDiscoveryEnv, TreeState, ExpressionNode
+from janus_ai.environments.base.symbolic_env import SymbolicDiscoveryEnv, TreeState, ExpressionNode
 
 # Import core expression and symbolic math utilities
-from JanusAI.core.expressions.expression import Expression, Variable
-from JanusAI.core.expressions.symbolic_math import get_variables_from_expression, evaluate_expression_on_data
+from janus_ai.core.expressions.expression import Expression, Variable
+from janus_ai.core.expressions.symbolic_math import get_variables_from_expression, evaluate_expression_on_data
 
 # Import physics-specific utilities
-from JanusAI.physics.laws.conservation import ConservationDetector # For potential use in reward
+from janus_ai.physics.laws.conservation import ConservationDetector # For potential use in reward
 # Import PhysicsTask from the new task_distribution module
-from JanusAI.physics.data.task_distribution import PhysicsTask
+from janus_ai.physics.data.task_distribution import PhysicsTask
 
 
 class PhysicsEnvironment(SymbolicDiscoveryEnv):
@@ -71,7 +71,7 @@ class PhysicsEnvironment(SymbolicDiscoveryEnv):
             provide_tree_structure=provide_tree_structure
         )
         self.physics_task = physics_task
-        
+
         # Convert variable names from PhysicsTask into Variable objects for the environment
         # This mapping is crucial for `SymbolicDiscoveryEnv` and expression evaluation
         self.variables: List[Variable] = []
@@ -89,7 +89,7 @@ class PhysicsEnvironment(SymbolicDiscoveryEnv):
         # self.physical_constants = physics_task.physical_parameters
         # self.true_law_sympy = sp.sympify(physics_task.true_law)
         # self.true_law_str = physics_task.true_law
-        
+
         # Initialize ConservationDetector if rewards use it
         self.conservation_detector = ConservationDetector()
 
@@ -103,7 +103,7 @@ class PhysicsEnvironment(SymbolicDiscoveryEnv):
         # `n_samples` should be based on `self.num_steps` if that's still relevant, or a default.
         # Let's generate 1000 samples for the episode's data.
         episode_data_matrix = self.physics_task.generate_data(n_samples=1000, add_noise=self.physics_task.noise_level > 0)
-        
+
         # Update the target_data in the SymbolicDiscoveryEnv base class.
         # Assumes the last column of the generated data is the target (dependent variable).
         # This convention needs to be consistent with how `PhysicsTask` lists `variables`.
@@ -111,7 +111,7 @@ class PhysicsEnvironment(SymbolicDiscoveryEnv):
 
         # The initial observation for the agent (e.g., encoded blank tree, or initial state)
         # The base `SymbolicDiscoveryEnv.reset` will handle the initial observation.
-        
+
         # Pass relevant physics-specific info to the info dict
         info = {
             'trajectory_data': {}, # Will be populated from episode_data_matrix
@@ -209,7 +209,7 @@ if __name__ == "__main__":
             truncated = False
             info = {}
             # Mock expression in info
-            info['expression'] = "x_0 + 1" 
+            info['expression'] = "x_0 + 1"
             info['complexity'] = 5
             return next_obs, reward, done, truncated, info
 
@@ -264,4 +264,3 @@ if __name__ == "__main__":
 
     # Clean up mock
     del sys.modules['janus.environments.base.symbolic_env'].SymbolicDiscoveryEnv
-

--- a/JanusAI/environments/base/symbolic_env.py
+++ b/JanusAI/environments/base/symbolic_env.py
@@ -17,10 +17,10 @@ from enum import Enum, auto
 # Import necessary modules (adjust paths as needed)
 
 
-from JanusAI.core.grammar.progressive_grammar import ProgressiveGrammar # Updated import
-from JanusAI.core.expressions.expression import Expression, Variable
-from JanusAI.utils.math.operations import calculate_expression_complexity
-from JanusAI.core.expressions.symbolic_math import evaluate_expression_on_data
+from janus_ai.core.grammar.progressive_grammar import ProgressiveGrammar # Updated import
+from janus_ai.core.expressions.expression import Expression, Variable
+from janus_ai.utils.math.operations import calculate_expression_complexity
+from janus_ai.core.expressions.symbolic_math import evaluate_expression_on_data
 from memory.dual_memory_system import SharedMemory # Added import
 
 

--- a/JanusAI/experiments/configs/generic.py
+++ b/JanusAI/experiments/configs/generic.py
@@ -5,12 +5,12 @@
 import numpy as np
 from typing import Type, Optional
 
-from JanusAI.experiments.base import BaseExperiment
-from JanusAI.experiments.registry import register_experiment
-from JanusAI.config.models import ExperimentResult
-from JanusAI.physics.environments.base import PhysicsEnvironment
-from JanusAI.core.grammar import ProgressiveGrammar
-from JanusAI.core.expression import Variable
+from janus_ai.experiments.base import BaseExperiment
+from janus_ai.experiments.registry import register_experiment
+from janus_ai.config.models import ExperimentResult
+from janus_ai.physics.environments.base import PhysicsEnvironment
+from janus_ai.core.grammar import ProgressiveGrammar
+from janus_ai.core.expression import Variable
 
 
 @register_experiment(

--- a/JanusAI/experiments/configs/harmonic_oscillator.py
+++ b/JanusAI/experiments/configs/harmonic_oscillator.py
@@ -5,13 +5,13 @@
 import numpy as np
 from typing import List, Dict, Any
 
-from JanusAI.experiments.base import BaseExperiment
-from JanusAI.experiments.registry import register_experiment
-from JanusAI.config.models import ExperimentResult
-from JanusAI.physics.environments.harmonic import HarmonicOscillatorEnv
-from JanusAI.physics.algorithms import create_algorithm
-from JanusAI.core.grammar import ProgressiveGrammar
-from JanusAI.core.expression import Variable
+from janus_ai.experiments.base import BaseExperiment
+from janus_ai.experiments.registry import register_experiment
+from janus_ai.config.models import ExperimentResult
+from janus_ai.physics.environments.harmonic import HarmonicOscillatorEnv
+from janus_ai.physics.algorithms import create_algorithm
+from janus_ai.core.grammar import ProgressiveGrammar
+from janus_ai.core.expression import Variable
 
 
 @register_experiment(

--- a/JanusAI/experiments/configs/run_gpt_2_attention_experiment.py
+++ b/JanusAI/experiments/configs/run_gpt_2_attention_experiment.py
@@ -17,14 +17,14 @@ from transformers import GPT2Model, GPT2Tokenizer
 from dataclasses import dataclass
 from typing import Dict, List, Any, Optional
 
-from JanusAI.experiments.registry import register_experiment
-from JanusAI.experiments.base import BaseExperiment
-from JanusAI.experiments.config import GPT2AttentionConfig as RegistryConfig
-from JanusAI.ai_interpretability.evaluation.fidelity import FidelityCalculator
-from JanusAI.core.grammar import EnhancedAIGrammar
-from JanusAI.ai_interpretability.rewards.interpretability_reward import InterpretabilityReward
-from JanusAI.environments.base.symbolic_env import SymbolicDiscoveryEnv
-from JanusAI.ml.training.ppo_trainer import PPOTrainer
+from janus_ai.experiments.registry import register_experiment
+from janus_ai.experiments.base import BaseExperiment
+from janus_ai.experiments.config import GPT2AttentionConfig as RegistryConfig
+from janus_ai.ai_interpretability.evaluation.fidelity import FidelityCalculator
+from janus_ai.core.grammar import EnhancedAIGrammar
+from janus_ai.ai_interpretability.rewards.interpretability_reward import InterpretabilityReward
+from janus_ai.environments.base.symbolic_env import SymbolicDiscoveryEnv
+from janus_ai.ml.training.ppo_trainer import PPOTrainer
 
 # Device for computation
 DEVICE = torch.device('cuda' if torch.cuda.is_available() else 'cpu')

--- a/JanusAI/experiments/data/__init__.py
+++ b/JanusAI/experiments/data/__init__.py
@@ -1,6 +1,6 @@
 # JanusAI/experiments/data/__init__.py
 
-from .attention_data_generator import AttentionDataGenerator
+from janus_ai.experiments.data.attention_data_generator import AttentionDataGenerator
 
 __all__ = [
     "AttentionDataGenerator"

--- a/JanusAI/experiments/runner/base_runner.py
+++ b/JanusAI/experiments/runner/base_runner.py
@@ -13,17 +13,17 @@ import time
 from typing import Any, Dict, List, Optional, Tuple, Type, Callable
 
 # Import core components
-from JanusAI.core.grammar.progressive_grammar import ProgressiveGrammar # Updated import
-from JanusAI.core.expressions.expression import Variable, Expression
+from janus_ai.core.grammar.progressive_grammar import ProgressiveGrammar # Updated import
+from janus_ai.core.expressions.expression import Variable, Expression
 
 # Import environment and policy (assuming specific types like SymbolicDiscoveryEnv and HypothesisNet)
-from JanusAI.environments.base.symbolic_env import SymbolicDiscoveryEnv
-from JanusAI.ml.networks.hypothesis_net import HypothesisNet
-from JanusAI.ml.training.ppo_trainer import PPOTrainer # Assuming PPOTrainer is the default trainer
+from janus_ai.environments.base.symbolic_env import SymbolicDiscoveryEnv
+from janus_ai.ml.networks.hypothesis_net import HypothesisNet
+from janus_ai.ml.training.ppo_trainer import PPOTrainer # Assuming PPOTrainer is the default trainer
 
 # Import logging utilities
-from JanusAI.utils.logging.experiment_logger import TrainingLogger
-from JanusAI.utils.io.checkpoint_manager import CheckpointManager # For saving/loading models
+from janus_ai.utils.logging.experiment_logger import TrainingLogger
+from janus_ai.utils.io.checkpoint_manager import CheckpointManager # For saving/loading models
 
 # Forward declaration for type hinting if needed (though Python 3.7+ usually handles this with strings)
 # from janus.config.models import ExperimentConfig # If ExperimentConfig is available

--- a/JanusAI/experiments/runner/gpt2_attn_experiment.py
+++ b/JanusAI/experiments/runner/gpt2_attn_experiment.py
@@ -9,11 +9,11 @@ import torch
 from transformers import GPT2Model, GPT2Tokenizer
 
 # Janus imports
-from JanusAI.ai_interpretability.evaluation.fidelity import FidelityCalculator
-from JanusAI.core.grammar import EnhancedAIGrammar
-from JanusAI.ai_interpretability.rewards.interpretability_reward import InterpretabilityReward
-from JanusAI.environments.base.symbolic_env import SymbolicDiscoveryEnv
-from JanusAI.ml.training.ppo_trainer import PPOTrainer
+from janus_ai.ai_interpretability.evaluation.fidelity import FidelityCalculator
+from janus_ai.core.grammar import EnhancedAIGrammar
+from janus_ai.ai_interpretability.rewards.interpretability_reward import InterpretabilityReward
+from janus_ai.environments.base.symbolic_env import SymbolicDiscoveryEnv
+from janus_ai.ml.training.ppo_trainer import PPOTrainer
 
 
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')

--- a/JanusAI/experiments/train/__init__.py
+++ b/JanusAI/experiments/train/__init__.py
@@ -1,6 +1,6 @@
 # JanusAI/experiments/train/__init__.py
 
-from .train_attention_discovery import train_attention_discovery
+from janus_ai.experiments.train.train_attention_discovery import train_attention_discovery
 
 __all__ = [
     "train_attention_discovery"

--- a/JanusAI/experiments/train/train_attention_discovery.py
+++ b/JanusAI/experiments/train/train_attention_discovery.py
@@ -4,31 +4,31 @@ import random
 from typing import List, Dict, Any, Callable
 
 # Environment and Grammar
-from JanusAI.environments.base.symbolic_env import SymbolicDiscoveryEnv
-from JanusAI.core.grammar.base_grammar import AIGrammar # Assuming AIGrammar is the one for 'full_ai_grammar'
-from JanusAI.core.expressions.expression import Variable # For defining variables if needed
+from janus_ai.environments.base.symbolic_env import SymbolicDiscoveryEnv
+from janus_ai.core.grammar.base_grammar import AIGrammar # Assuming AIGrammar is the one for 'full_ai_grammar'
+from janus_ai.core.expressions.expression import Variable # For defining variables if needed
 
 # Rewards
 # Assuming InterpretabilityReward is in one of these locations.
-# from JanusAI.ai_interpretability.rewards.interpretability_reward import InterpretabilityReward
+# from janus_ai.ai_interpretability.rewards.interpretability_reward import InterpretabilityReward
 # Or
-from JanusAI.ml.rewards.interpretability_reward import InterpretabilityReward
+from janus_ai.ml.rewards.interpretability_reward import InterpretabilityReward
 
 # PPO Trainer and Components
 # These are placeholders, actual paths might differ.
-# from JanusAI.ml.training.ppo_trainer import AdvancedPPOTrainer, PPOConfig # Or enhanced_ppo_trainer
-from JanusAI.ml.training.enhaced_ppo_trainer import AdvancedPPOTrainer # Corrected based on file listing
-from JanusAI.ml.training.ppo_config import PPOConfig # Assuming ppo_config.py for PPOConfig
-# from JanusAI.ml.training.experience_buffer import ExperienceBuffer # Placeholder
+# from janus_ai.ml.training.ppo_trainer import AdvancedPPOTrainer, PPOConfig # Or enhanced_ppo_trainer
+from janus_ai.ml.training.enhaced_ppo_trainer import AdvancedPPOTrainer # Corrected based on file listing
+from janus_ai.ml.training.ppo_config import PPOConfig # Assuming ppo_config.py for PPOConfig
+# from janus_ai.ml.training.experience_buffer import ExperienceBuffer # Placeholder
 # For ExperienceBuffer, let's assume a path, e.g., from a utils or replay buffer module
-from JanusAI.utils.replay_buffer import ExperienceBuffer # Placeholder, might be utils.buffers or ml.buffers
+from janus_ai.utils.replay_buffer import ExperienceBuffer # Placeholder, might be utils.buffers or ml.buffers
 
 # Curriculum and Checkpoints
-from JanusAI.ml.training.curriculum import CurriculumManager # Assuming this path
-from JanusAI.utils.io.checkpoint_manager import CheckpointManager
+from janus_ai.ml.training.curriculum import CurriculumManager # Assuming this path
+from janus_ai.utils.io.checkpoint_manager import CheckpointManager
 
 # Data Generator
-from JanusAI.experiments.data.attention_data_generator import AttentionDataGenerator
+from janus_ai.experiments.data.attention_data_generator import AttentionDataGenerator
 
 # Policy Network (Placeholder - this would be a defined PyTorch nn.Module)
 class PlaceholderPolicy(torch.nn.Module):

--- a/JanusAI/experiments/xolver_enhanced_discovery.py
+++ b/JanusAI/experiments/xolver_enhanced_discovery.py
@@ -12,13 +12,13 @@ from dataclasses import dataclass
 import json
 
 # Import Janus components
-from ..ml.training.advanced_ppo_trainer import AdvancedPPOTrainer, PPOConfig
-from ..ml.training.discovery_self_play import DiscoverySelfPlaySystem, NeuralDiscoveryAgent
-from ..ml.training.advanced_meta_learning import MetaLearner, AdvancedMetaTrainer
-from ..environments.hierarchical_discovery_env import HierarchicalDiscoveryEnv
-from ..ml.agents.xolver_scientific_agents import XolverScientificDiscoverySystem
-from ..grammar.ai_grammar import AIGrammar
-from ..rewards.interpretability_reward import InterpretabilityReward
+from janus_ai.ml.training.advanced_ppo_trainer import AdvancedPPOTrainer, PPOConfig
+from janus_ai.ml.training.discovery_self_play import DiscoverySelfPlaySystem, NeuralDiscoveryAgent
+from janus_ai.ml.training.advanced_meta_learning import MetaLearner, AdvancedMetaTrainer
+from janus_ai.environments.hierarchical_discovery_env import HierarchicalDiscoveryEnv
+from janus_ai.ml.agents.xolver_scientific_agents import XolverScientificDiscoverySystem
+from janus_ai.core.grammar.ai_grammar import AIGrammar # Adjusted path
+from janus_ai.ai_interpretability.rewards.interpretability_reward import InterpretabilityReward # Adjusted path
 
 
 class XolverEnhancedJanusPipeline:
@@ -63,7 +63,7 @@ class XolverEnhancedJanusPipeline:
         )
         
         # Base policy network (shared across agents)
-        from ..ml.networks.policy_networks import TransformerPolicy
+        from janus_ai.ml.networks.policy_networks import TransformerPolicy
         
         self.base_policy = TransformerPolicy(
             obs_dim=256,  # Larger for richer representations
@@ -93,7 +93,7 @@ class XolverEnhancedJanusPipeline:
         
         # Meta-learner for rapid adaptation
         if self.enable_meta_learning:
-            from ..ml.training.advanced_meta_learning import MetaLearningConfig
+            from janus_ai.ml.training.advanced_meta_learning import MetaLearningConfig
             
             meta_config = MetaLearningConfig(
                 learn_inner_lr=True,
@@ -187,7 +187,7 @@ class XolverEnhancedJanusPipeline:
     def _meta_learning_warmup(self, domain: str, num_steps: int):
         """Warm up with meta-learning on synthetic tasks"""
         
-        from ..ml.training.advanced_meta_learning import ScientificTaskDistribution
+        from janus_ai.ml.training.advanced_meta_learning import ScientificTaskDistribution
         
         task_distribution = ScientificTaskDistribution(
             domains=[domain],

--- a/JanusAI/integration/__init__.py
+++ b/JanusAI/integration/__init__.py
@@ -20,8 +20,8 @@ Core Schemas:
  - `AgentRole`, `MessageType`: Enums for defining agent and message types.
 
 Example Usage:
-    from JanusAI.integration import run_training_pipeline, AdvancedJanusTrainer
-    from JanusAI.config import JanusConfig
+    from janus_ai.integration import run_training_pipeline, AdvancedJanusTrainer
+    from janus_ai.config import JanusConfig
 
     # Configure and run a multi-agent experiment
     config = JanusConfig(training_mode="multi_agent", ...)
@@ -40,7 +40,7 @@ __author__ = "JanusAI Team"
 # --- Public API for the Integration Package ---
 
 # Core data structures for type hinting and message creation
-from .schemas import (
+from janus_ai.integration.schemas import (
     AgentRole,
     MessageType,
     Discovery,
@@ -48,20 +48,20 @@ from .schemas import (
 )
 
 # Core infrastructure for advanced use cases
-from .knowledge import (
+from janus_ai.integration.knowledge import (
     MessageBus,
     SharedKnowledgeBase
 )
 
 # Core agent and communication modules
-from .agent import (
+from janus_ai.integration.agent import (
     DiscoveryAgent,
     CommunicationEncoder,
     CommunicationAggregator
 )
 
 # Primary pipeline and trainer entry points
-from .pipeline import (
+from janus_ai.integration.pipeline import (
     JanusTrainer,
     AdvancedJanusTrainer,
     create_trainer,
@@ -70,11 +70,11 @@ from .pipeline import (
 )
 
 # Expose sub-modules for advanced, direct import
-from . import distributed
-from . import meta_learning
+from janus_ai.integration import distributed
+from janus_ai.integration import meta_learning
 
 
-# Define what is exposed when a user does 'from JanusAI.integration import *'
+# Define what is exposed when a user does 'from janus_ai.integration import *'
 __all__ = [
     # High-level pipeline functions
     "run_training_pipeline",

--- a/JanusAI/integration/agent.py
+++ b/JanusAI/integration/agent.py
@@ -25,8 +25,8 @@ from datetime import datetime
 from dataclasses import dataclass
 
 # Import schemas and infrastructure
-from .schemas import AgentRole, MessageType, Discovery, Message
-from .knowledge import SharedKnowledgeBase
+from janus_ai.integration.schemas import AgentRole, MessageType, Discovery, Message
+from janus_ai.integration.knowledge import SharedKnowledgeBase
 
 logger = logging.getLogger(__name__)
 

--- a/JanusAI/integration/distributed.py
+++ b/JanusAI/integration/distributed.py
@@ -17,48 +17,48 @@ from typing import Dict, List, Any, Tuple
 
 # --- Internal Janus Imports (adjusted for new structure) ---
 # Import the DistributedJanusTrainer from its new location
-from JanusAI.experiments.runner.distributed_runner import DistributedJanusTrainer
-from JanusAI.core.grammar.progressive_grammar import ProgressiveGrammar # Updated import
-from JanusAI.core.expressions.expression import Variable # Assuming this is the new path
-from JanusAI.environments.base.symbolic_env import SymbolicDiscoveryEnv # Assuming this is the new path
+from janus_ai.experiments.runner.distributed_runner import DistributedJanusTrainer
+from janus_ai.core.grammar.progressive_grammar import ProgressiveGrammar # Updated import
+from janus_ai.core.expressions.expression import Variable # Assuming this is the new path
+from janus_ai.environments.base.symbolic_env import SymbolicDiscoveryEnv # Assuming this is the new path
 
 
-def create_placement_group_for_training(num_workers: int, 
+def create_placement_group_for_training(num_workers: int,
                                       gpus_per_worker: float = 0.5) -> Any:
     """
     Create a Ray placement group for efficient resource allocation across nodes/GPUs.
-    
+
     This function defines the resource bundles for the Ray cluster, including
     resources for the driver process and individual workers, and ensures they
     are spread across available nodes.
-    
+
     Args:
         num_workers (int): The number of worker actors to accommodate.
         gpus_per_worker (float): The number of GPUs to allocate per worker.
                                  Can be fractional.
-                                 
+
     Returns:
         Any: The created Ray placement group object.
     """
-    
+
     bundles = []
-    
+
     # Bundle for the driver process (if it needs dedicated resources).
     # This is an example, adjust based on actual driver resource needs.
-    bundles.append({"CPU": 2, "GPU": 0.5}) 
-    
+    bundles.append({"CPU": 2, "GPU": 0.5})
+
     # Bundles for each worker. Each worker gets a specified amount of CPU and GPU.
     for _ in range(num_workers):
         bundles.append({
             "CPU": 2, # Example CPU per worker, adjust as needed
             "GPU": gpus_per_worker # Fractional or whole GPU per worker
         })
-    
+
     # Create the placement group with a 'SPREAD' strategy to distribute across nodes
     # This helps in utilizing resources on different physical machines.
     pg = placement_group(bundles, strategy="SPREAD")
     ray.get(pg.ready()) # Wait for the placement group to be ready and resources allocated
-    
+
     return pg
 
 
@@ -68,22 +68,22 @@ def distributed_hyperparameter_search(grammar: ProgressiveGrammar,
                                     num_trials: int = 20) -> Dict[str, Any]:
     """
     Run a distributed hyperparameter search using Ray Tune.
-    
+
     This function sets up and executes a hyperparameter optimization process
     for the PPO algorithm, integrating with the custom HypothesisNet model
     and SymbolicDiscoveryEnv. It uses Ray Tune to manage trials and resources.
-    
+
     Args:
         grammar (ProgressiveGrammar): The grammar object used for expression generation.
         env_config (Dict[str, Any]): Configuration dictionary for the environment.
         search_space (Dict[str, Any]): A dictionary defining the hyperparameter
                                         search space using `ray.tune` primitives.
         num_trials (int): The number of different hyperparameter combinations to try.
-        
+
     Returns:
         Dict[str, Any]: The best configuration found by the hyperparameter search.
     """
-    
+
     # Base configuration for the RLlib PPO algorithm.
     # This includes default settings and placeholders for tunable parameters.
     config = {
@@ -108,11 +108,11 @@ def distributed_hyperparameter_search(grammar: ProgressiveGrammar,
         "num_cpus_per_worker": 2, # CPUs for each rollout worker within a trial
         "num_rollout_workers": 1, # Number of parallel rollout workers per trial
     }
-    
+
     # Overlay any custom search parameters provided by the user.
     # This allows for flexible definition of the search space from external configurations.
     config.update(search_space)
-    
+
     # Run the hyperparameter search using Ray Tune.
     # It manages the creation and execution of multiple trials in parallel.
     analysis = tune.run(
@@ -124,7 +124,7 @@ def distributed_hyperparameter_search(grammar: ProgressiveGrammar,
         mode="max", # The optimization goal (maximize the metric)
         resources_per_trial={"cpu": 4, "gpu": 0.5} # Resources allocated per trial (PPO trainer + its workers)
     )
-    
+
     # Return the best configuration found by the search based on the specified metric and mode.
     return analysis.best_config
 
@@ -141,20 +141,20 @@ def run_distributed_janus_workflow(num_workers: int = 4, num_gpus: int = 2):
     print("Initializing Ray...")
     if not ray.is_initialized():
         ray.init(num_cpus=num_workers * 2, num_gpus=num_gpus, ignore_reinit_error=True)
-    
+
     # Setup necessary components (grammar, variables, data)
     grammar = ProgressiveGrammar()
     variables = [
         Variable("x", 0, {"smoothness": 0.9}),
         Variable("v", 1, {"conservation_score": 0.8})
     ]
-    
+
     n_samples = 1000
     x_data = np.linspace(-2, 2, n_samples)
     v_data = -2 * x_data  # Example: Linear relationship
     energy = x_data**2 + v_data**2  # Example: Quadratic energy function
     data = np.column_stack([x_data, v_data, energy])
-    
+
     env_config = {
         'grammar': grammar,
         'target_data': data,
@@ -163,7 +163,7 @@ def run_distributed_janus_workflow(num_workers: int = 4, num_gpus: int = 2):
         'max_complexity': 15,
         'reward_config': {'mse_weight': 1.0, 'complexity_weight': 0.01} # Example reward config
     }
-    
+
     print("Creating DistributedJanusTrainer...")
     trainer = DistributedJanusTrainer(
         grammar=grammar,
@@ -171,17 +171,17 @@ def run_distributed_janus_workflow(num_workers: int = 4, num_gpus: int = 2):
         num_workers=num_workers,
         num_gpus=num_gpus
     )
-    
+
     print("\n--- Starting Population Based Training (PBT) ---")
     best_trial = trainer.train_with_pbt(num_iterations=50, checkpoint_dir="./ray_results")
-    
+
     if best_trial:
         print(f"\nBest trial found:\nConfig: {best_trial.config}")
         print(f"Mean Episode Reward: {best_trial.last_result['episode_reward_mean']:.3f}")
-        
+
         # Load best policy weights for subsequent search
         best_policy_path = Path(best_trial.checkpoint.path) / "policies" / "default_policy"
-        
+
         # NOTE: This assumes the checkpoint structure from RLlib PPO.
         # You might need to adjust how weights are loaded based on your specific
         # HypothesisNet saving mechanism. Typically, RLlib stores weights as a dictionary
@@ -189,20 +189,20 @@ def run_distributed_janus_workflow(num_workers: int = 4, num_gpus: int = 2):
         # For simplicity here, we'll just demonstrate passing the best config
         # and assume a mechanism to load weights. A more robust solution
         # would involve restoring the trainer from the best_trial.checkpoint.
-        
+
         # For demonstration, let's pretend we can extract weights
         # In a real scenario, you'd do:
         # restored_trainer = PPO(config=best_trial.config, env=SymbolicDiscoveryEnv)
         # restored_trainer.restore(best_trial.checkpoint.path)
         # policy_weights = restored_trainer.get_policy("default_policy").get_weights()
         # restored_trainer.stop()
-        
+
         # Dummy policy weights for demonstration without actual restoration logic
         policy_weights_example = {
-            "dummy_weight_param_1": np.array([0.1, 0.2]), 
+            "dummy_weight_param_1": np.array([0.1, 0.2]),
             "dummy_weight_param_2": np.array([0.3, 0.4])
         }
-        
+
         print("\n--- Starting Parallel Hypothesis Search ---")
         all_discoveries = trainer.parallel_hypothesis_search(
             policy_weights=policy_weights_example, # Replace with actual loaded weights
@@ -210,14 +210,14 @@ def run_distributed_janus_workflow(num_workers: int = 4, num_gpus: int = 2):
             episodes_per_round=50
         )
         print(f"\nTotal unique discoveries: {len(set(all_discoveries))}")
-        
+
         print("\n--- Starting Adaptive Curriculum Search ---")
         final_policy_weights = trainer.adaptive_curriculum_search(
             initial_policy_weights=policy_weights_example, # Replace with actual loaded weights
             num_stages=3
         )
         print("Adaptive curriculum search completed.")
-        
+
     else:
         print("No best trial found from PBT.")
 
@@ -228,4 +228,3 @@ def run_distributed_janus_workflow(num_workers: int = 4, num_gpus: int = 2):
 if __name__ == "__main__":
     # Example of how to run the high-level distributed workflow
     run_distributed_janus_workflow(num_workers=4, num_gpus=2)
-

--- a/JanusAI/integration/knowledge.py
+++ b/JanusAI/integration/knowledge.py
@@ -25,7 +25,8 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
 # Import data structures from schemas module
-from .schemas import AgentRole, MessageType, Discovery, Message
+from janus_ai.schemas import AgentRole, MessageType, Discovery, Message
+
 
 # Configure logging
 logger = logging.getLogger(__name__)

--- a/JanusAI/integration/meta_learning.py
+++ b/JanusAI/integration/meta_learning.py
@@ -6,8 +6,8 @@ import traceback
 import torch
 
 # Import the necessary components from their new locations
-from JanusAI.ml.training.meta_trainer import MetaLearningConfig, MetaLearningPolicy, MAMLTrainer, TaskEnvironmentBuilder
-from JanusAI.physics.data.generators import PhysicsTaskDistribution
+from janus_ai.ml.training.meta_trainer import MetaLearningConfig, MetaLearningPolicy, MAMLTrainer, TaskEnvironmentBuilder
+from janus_ai.physics.data.generators import PhysicsTaskDistribution
 
 
 def main():

--- a/JanusAI/memory/advanced_features.py
+++ b/JanusAI/memory/advanced_features.py
@@ -18,7 +18,8 @@ from sklearn.cluster import DBSCAN
 import zipfile
 import io
 
-from .dual_memory_system import (
+from janus_ai.dual_memory_system import (
+
     DualMemorySystem, Discovery, IntermediateResult,
     EpisodicMemory, SharedMemory, EmbeddingGenerator
 )

--- a/JanusAI/memory/memory_system_usage.py
+++ b/JanusAI/memory/memory_system_usage.py
@@ -10,12 +10,13 @@ from typing import Dict, List, Optional, Any, Callable
 from datetime import datetime
 import logging
 
-from .dual_memory_system import (
+from janus_ai.dual_memory_system import (
+
     DualMemorySystem, Discovery, IntermediateResult, 
     EmbeddingGenerator, SharedMemory
 )
-from ..environments.symbolic_discovery_env import SymbolicDiscoveryEnv
-from ..grammar.expression_tree import ExpressionTree
+from janus_ai.environments.symbolic_discovery_env import SymbolicDiscoveryEnv
+from janus_ai.grammar.expression_tree import ExpressionTree
 
 
 class MemoryIntegratedEnv(SymbolicDiscoveryEnv):

--- a/JanusAI/ml/agents/__init__.py
+++ b/JanusAI/ml/agents/__init__.py
@@ -1,7 +1,11 @@
-from .hypothesis_generator import HypothesisGenerator
-from .integration import JanusMultiAgentFramework, MultiAgentEnvironmentWrapper
-from .iterative_refinement import IterativeRefinementLoop, JudgeAgent as RefinementJudgeAgent, IterationMetrics
-from .multi_agent_system import (
+from janus_ai.ml.hypothesis_generator import HypothesisGenerator
+
+from janus_ai.ml.integration import JanusMultiAgentFramework, MultiAgentEnvironmentWrapper
+
+from janus_ai.ml.iterative_refinement import IterativeRefinementLoop, JudgeAgent as RefinementJudgeAgent, IterationMetrics
+
+from janus_ai.ml.multi_agent_system import (
+
     BaseScientificAgent,
     DynamicAgentPool,
     # PlannerAgent, # Not found in the provided snippet of multi_agent_system.py
@@ -13,8 +17,10 @@ from .multi_agent_system import (
     ValidatorAgent as MASystemValidatorAgent,
     CriticAgent as MASystemCriticAgent
 )
-from .task_setter import TaskSetterAgent, TaskSetterConfig, TaskSetterEnv
-from .xolver_scientific_agents import (
+from janus_ai.ml.task_setter import TaskSetterAgent, TaskSetterConfig, TaskSetterEnv
+
+from janus_ai.ml.xolver_scientific_agents import (
+
     ScientificAgent as XolverScientificAgent,
     HypothesisGeneratorAgent as XolverHypothesisGeneratorAgent,
     ExperimentDesignerAgent as XolverExperimentDesignerAgent,

--- a/JanusAI/ml/agents/hypothesis_generator.py
+++ b/JanusAI/ml/agents/hypothesis_generator.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional
 
 # Assuming ScientificAgent is in xolver_scientific_agents
 # Adjust the import path if necessary based on your project structure
-from JanusAI.ml.agents.xolver_scientific_agents import ScientificAgent
+from janus_ai.ml.agents.xolver_scientific_agents import ScientificAgent
 # Assuming SharedMemory is in memory.dual_memory_system
 # Adjust the import path if necessary
 from memory.dual_memory_system import SharedMemory

--- a/JanusAI/ml/agents/integration.py
+++ b/JanusAI/ml/agents/integration.py
@@ -11,22 +11,31 @@ from datetime import datetime
 import logging
 
 # Import Janus components
-from .multi_agent_system import (
+from janus_ai.ml.multi_agent_system import (
+
     DynamicAgentPool, PlannerAgent, AgentRole, AgentConfig,
     BaseScientificAgent
 )
-from .iterative_refinement import (
+from janus_ai.ml.iterative_refinement import (
+
     IterativeRefinementLoop, JudgeAgent, FeedbackIncorporator
 )
-from ..memory.dual_memory_system import DualMemorySystem
-from ..memory.memory_integration import (
+from janus_ai.memory.dual_memory_system import DualMemorySystem
+
+from janus_ai.memory.memory_integration import (
+
     MemoryIntegratedEnv, MemoryAugmentedAgent
 )
-from ..grammar.ai_grammar import AIGrammar
-from ..rewards.interpretability_reward import InterpretabilityReward
-from ..ml.training.advanced_ppo_trainer import AdvancedPPOTrainer, PPOConfig
-from ..ml.networks.policy_networks import TransformerPolicy
-from ..environments.symbolic_discovery_env import SymbolicDiscoveryEnv
+from janus_ai.grammar.ai_grammar import AIGrammar
+
+from janus_ai.rewards.interpretability_reward import InterpretabilityReward
+
+from janus_ai.ml.training.advanced_ppo_trainer import AdvancedPPOTrainer, PPOConfig
+
+from janus_ai.ml.networks.policy_networks import TransformerPolicy
+
+from janus_ai.environments.symbolic_discovery_env import SymbolicDiscoveryEnv
+
 
 
 class JanusMultiAgentFramework:

--- a/JanusAI/ml/agents/iterative_refinement.py
+++ b/JanusAI/ml/agents/iterative_refinement.py
@@ -12,17 +12,23 @@ import logging
 from dataclasses import dataclass
 from collections import deque
 
-from .multi_agent_system import (
+from janus_ai.ml.multi_agent_system import (
+
     BaseScientificAgent, DynamicAgentPool, PlannerAgent,
     AgentRole, AgentConfig
 )
-from ..memory.dual_memory_system import (
+from janus_ai.memory.dual_memory_system import (
+
     DualMemorySystem, IntermediateResult, Discovery
 )
-from ..grammar.ai_grammar import AIGrammar
-from ..rewards.interpretability_reward import InterpretabilityReward
-from ..ml.training.advanced_ppo_trainer import AdvancedPPOTrainer, PPOConfig
-from ..environments.symbolic_discovery_env import SymbolicDiscoveryEnv
+from janus_ai.grammar.ai_grammar import AIGrammar
+
+from janus_ai.rewards.interpretability_reward import InterpretabilityReward
+
+from janus_ai.ml.training.advanced_ppo_trainer import AdvancedPPOTrainer, PPOConfig
+
+from janus_ai.environments.symbolic_discovery_env import SymbolicDiscoveryEnv
+
 
 
 @dataclass

--- a/JanusAI/ml/agents/multi_agent_system.py
+++ b/JanusAI/ml/agents/multi_agent_system.py
@@ -15,14 +15,20 @@ import logging
 from enum import Enum
 import json
 
-from ..memory.dual_memory_system import (
+from janus_ai.memory.dual_memory_system import (
+
     DualMemorySystem, Discovery, IntermediateResult
 )
-from ..grammar.ai_grammar import AIGrammar
-from ..grammar.expression_tree import ExpressionTree
-from ..rewards.interpretability_reward import InterpretabilityReward
-from ..ml.training.advanced_ppo_trainer import AdvancedPPOTrainer
-from ..ml.networks.policy_networks import TransformerPolicy
+from janus_ai.grammar.ai_grammar import AIGrammar
+
+from janus_ai.grammar.expression_tree import ExpressionTree
+
+from janus_ai.rewards.interpretability_reward import InterpretabilityReward
+
+from janus_ai.ml.training.advanced_ppo_trainer import AdvancedPPOTrainer
+
+from janus_ai.ml.networks.policy_networks import TransformerPolicy
+
 
 
 class AgentRole(Enum):

--- a/JanusAI/ml/agents/task_setter.py
+++ b/JanusAI/ml/agents/task_setter.py
@@ -18,7 +18,7 @@ from stable_baselines3.common.vec_env import DummyVecEnv
 from stable_baselines3.common.policies import ActorCriticPolicy
 from gymnasium import spaces
 
-from JanusAI.physics.data.generators import PhysicsTask
+from janus_ai.physics.data.generators import PhysicsTask
 
 
 @dataclass

--- a/JanusAI/ml/agents/xolver_scientific_agents.py
+++ b/JanusAI/ml/agents/xolver_scientific_agents.py
@@ -12,9 +12,9 @@ from collections import defaultdict, deque
 from abc import ABC, abstractmethod
 import json
 
-from ...grammar.expression_tree import ExpressionTree
-from ...grammar.ai_grammar import AIGrammar
-from ...environments.symbolic_discovery_env import SymbolicDiscoveryEnv
+from janus_ai.grammar.expression_tree import ExpressionTree
+from janus_ai.grammar.ai_grammar import AIGrammar
+from janus_ai.environments.symbolic_discovery_env import SymbolicDiscoveryEnv
 
 
 @dataclass

--- a/JanusAI/ml/networks/hypothesis_net.py
+++ b/JanusAI/ml/networks/hypothesis_net.py
@@ -17,10 +17,10 @@ from typing import Dict, List, Tuple, Optional, Any, Union, TypedDict
 from dataclasses import dataclass
 
 # Internal project imports based on new structure
-from JanusAI.environments.base.symbolic_env import SymbolicDiscoveryEnv, safe_env_reset
-from JanusAI.core.grammar.progressive_grammar import ProgressiveGrammar # Updated import
-from JanusAI.core.expressions.expression import Variable
-from JanusAI.utils.general_utils import safe_import # Assuming this new utility file will be created
+from janus_ai.environments.base.symbolic_env import SymbolicDiscoveryEnv, safe_env_reset
+from janus_ai.core.grammar.progressive_grammar import ProgressiveGrammar # Updated import
+from janus_ai.core.expressions.expression import Variable
+from janus_ai.utils.general_utils import safe_import # Assuming this new utility file will be created
 
 
 # Use safe_import for wandb. It's conditionally imported here but not directly used within the classes themselves.

--- a/JanusAI/ml/rewards/reward_handler.py
+++ b/JanusAI/ml/rewards/reward_handler.py
@@ -14,7 +14,7 @@ import logging
 from dataclasses import dataclass
 from abc import ABC, abstractmethod
 
-from JanusAI.ml.rewards.base_reward import BaseReward
+from janus_ai.ml.rewards.base_reward import BaseReward
 
 
 @dataclass

--- a/JanusAI/ml/rewards/reward_registry.py
+++ b/JanusAI/ml/rewards/reward_registry.py
@@ -11,13 +11,13 @@ from typing import Dict, Type, Any, Optional, Callable
 import inspect
 from functools import partial
 
-from JanusAI.ml.rewards.base_reward import BaseReward
-from JanusAI.ml.rewards.intrinsic_rewards import (
+from janus_ai.ml.rewards.base_reward import BaseReward
+from janus_ai.ml.rewards.intrinsic_rewards import (
     NoveltyReward,
     ComplexityReward,
     ConservationLawReward
 )
-from JanusAI.ml.rewards.interpretability_reward import InterpretabilityReward
+from janus_ai.ml.rewards.interpretability_reward import InterpretabilityReward
 
 
 # Global registry for reward components

--- a/JanusAI/ml/training/advanced_ppo_examples.py
+++ b/JanusAI/ml/training/advanced_ppo_examples.py
@@ -14,9 +14,9 @@ from concurrent.futures import ThreadPoolExecutor
 import pickle
 from pathlib import Path
 
-from JanusAI.ml.training.ppo_trainer import PPOTrainer, RolloutBuffer
-from JanusAI.environments.base.symbolic_env import SymbolicDiscoveryEnv
-from JanusAI.ml.networks.hypothesis_net import HypothesisNet
+from janus_ai.ml.training.ppo_trainer import PPOTrainer, RolloutBuffer
+from janus_ai.environments.base.symbolic_env import SymbolicDiscoveryEnv
+from janus_ai.ml.networks.hypothesis_net import HypothesisNet
 
 
 class DistributedPPOTrainer:

--- a/JanusAI/ml/training/advanced_ppo_trainer.py
+++ b/JanusAI/ml/training/advanced_ppo_trainer.py
@@ -14,10 +14,12 @@ import logging
 from dataclasses import dataclass
 from collections import deque
 
-from .base_trainer import BaseTrainer
-from ..rollouts.rollout_buffer import RolloutBuffer
-from ...utils.general_utils import safe_env_reset
-from ...utils.io.checkpoint_manager import CheckpointManager
+from janus_ai.ml.base_trainer import BaseTrainer
+
+from janus_ai.rollouts.rollout_buffer import RolloutBuffer
+
+from janus_ai.utils.general_utils import safe_env_reset
+from janus_ai.utils.io.checkpoint_manager import CheckpointManager
 
 
 @dataclass

--- a/JanusAI/ml/training/curriculum.py
+++ b/JanusAI/ml/training/curriculum.py
@@ -11,7 +11,7 @@ import time
 import numpy as np
 
 # Import the task distribution from its new location
-from JanusAI.physics.data.generators import PhysicsTaskDistribution
+from janus_ai.physics.data.generators import PhysicsTaskDistribution
 
 
 class CurriculumManager:

--- a/JanusAI/ml/training/ppo_trainer.py
+++ b/JanusAI/ml/training/ppo_trainer.py
@@ -20,17 +20,17 @@ from collections import deque
 from dataclasses import dataclass, field
 
 # Import necessary modules (adjust paths as needed)
-from JanusAI.ml.networks.hypothesis_net import HypothesisNet
-from JanusAI.environments.base.symbolic_env import SymbolicDiscoveryEnv
-from JanusAI.utils.io.checkpoint_manager import CheckpointManager
-from JanusAI.utils.general_utils import safe_env_reset
+from janus_ai.ml.networks.hypothesis_net import HypothesisNet
+from janus_ai.environments.base.symbolic_env import SymbolicDiscoveryEnv
+from janus_ai.utils.io.checkpoint_manager import CheckpointManager
+from janus_ai.utils.general_utils import safe_env_reset
 
 
 @dataclass
 class RolloutBuffer:
     """
     Storage for rollout data collected during environment interaction.
-    
+
     This buffer stores trajectories and computes advantages using GAE.
     """
     observations: List[np.ndarray] = field(default_factory=list)
@@ -43,7 +43,7 @@ class RolloutBuffer:
     returns: List[float] = field(default_factory=list)
     action_masks: List[np.ndarray] = field(default_factory=list)
     tree_structures: List[Optional[Dict]] = field(default_factory=list)
-    
+
     def reset(self):
         """Clear all stored data."""
         self.observations.clear()
@@ -56,7 +56,7 @@ class RolloutBuffer:
         self.returns.clear()
         self.action_masks.clear()
         self.tree_structures.clear()
-    
+
     def add(self, obs: np.ndarray, action: int, reward: float, value: float,
             log_prob: float, done: bool, action_mask: np.ndarray,
             tree_structure: Optional[Dict] = None):
@@ -69,7 +69,7 @@ class RolloutBuffer:
         self.dones.append(done)
         self.action_masks.append(action_mask)
         self.tree_structures.append(tree_structure)
-    
+
     def compute_returns_and_advantages(self, policy: nn.Module, gamma: float,
                                       gae_lambda: float,
                                       task_trajectories: Optional[torch.Tensor] = None):
@@ -83,12 +83,12 @@ class RolloutBuffer:
                 last_value = outputs['value'].item()
         else:
             last_value = 0.0
-        
+
         # Compute GAE
         advantages = []
         returns = []
         gae = 0.0
-        
+
         for t in reversed(range(len(self.rewards))):
             if t == len(self.rewards) - 1:
                 next_value = last_value
@@ -96,26 +96,26 @@ class RolloutBuffer:
             else:
                 next_value = self.values[t + 1]
                 next_done = self.dones[t + 1]
-            
+
             delta = self.rewards[t] + gamma * next_value * (1 - next_done) - self.values[t]
             gae = delta + gamma * gae_lambda * (1 - next_done) * gae
-            
+
             advantages.insert(0, gae)
             returns.insert(0, gae + self.values[t])
-        
+
         self.advantages = advantages
         self.returns = returns
-        
+
         # Normalize advantages
         adv_array = np.array(self.advantages)
-        self.advantages = ((adv_array - adv_array.mean()) / 
+        self.advantages = ((adv_array - adv_array.mean()) /
                           (adv_array.std() + 1e-8)).tolist()
-    
+
     def get(self) -> Dict[str, Any]:
         """Get all data as tensors."""
         obs_tensor = torch.FloatTensor(np.array(self.observations))
         action_masks_tensor = torch.BoolTensor(np.array(self.action_masks))
-        
+
         return {
             'observations': obs_tensor,
             'actions': torch.LongTensor(self.actions),
@@ -127,7 +127,7 @@ class RolloutBuffer:
             'action_masks': action_masks_tensor,
             'tree_structures': self.tree_structures
         }
-    
+
     def __len__(self) -> int:
         """Return the number of transitions stored."""
         return len(self.observations)
@@ -136,11 +136,11 @@ class RolloutBuffer:
 class PPOTrainer:
     """
     Refactored Proximal Policy Optimization (PPO) trainer.
-    
+
     This version separates data collection and learning phases for better
     modularity and follows modern RL library patterns.
     """
-    
+
     def __init__(
         self,
         policy: HypothesisNet,
@@ -159,7 +159,7 @@ class PPOTrainer:
     ):
         """
         Initialize PPO trainer.
-        
+
         Args:
             policy: The policy network (HypothesisNet)
             env: The environment for training
@@ -178,13 +178,13 @@ class PPOTrainer:
         self.policy = policy
         self.env = env
         self.device = device or torch.device("cuda" if torch.cuda.is_available() else "cpu")
-        
+
         # Move policy to device
         self.policy = self.policy.to(self.device)
-        
+
         # Optimizer
         self.optimizer = optim.Adam(policy.parameters(), lr=learning_rate)
-        
+
         # PPO hyperparameters
         self.n_epochs = n_epochs
         self.gamma = gamma
@@ -194,21 +194,21 @@ class PPOTrainer:
         self.entropy_coef = entropy_coef
         self.max_grad_norm = max_grad_norm
         self.batch_size = batch_size
-        
+
         # Rollout buffer
         self.rollout_buffer = RolloutBuffer()
-        
+
         # Tracking
         self.episode_rewards: Deque[float] = deque(maxlen=100)
         self.total_timesteps = 0
         self.n_updates = 0
-        
+
         # Checkpoint manager
         self.checkpoint_manager: Optional[CheckpointManager] = None
         if checkpoint_dir and CheckpointManager:
             os.makedirs(checkpoint_dir, exist_ok=True)
             self.checkpoint_manager = CheckpointManager(checkpoint_dir)
-    
+
     def collect_rollouts(
         self,
         n_steps: int,
@@ -218,40 +218,40 @@ class PPOTrainer:
     ) -> Dict[str, torch.Tensor]:
         """
         Collect experience from the environment for n_steps.
-        
+
         This method handles environment interaction and fills the rollout buffer.
-        
+
         Args:
             n_steps: Number of environment steps to collect
             task_trajectories: Optional task trajectories for meta-learning
             ai_model_representation: Optional AI model representation
             ai_model_type_idx: Optional AI model type index
-            
+
         Returns:
             Dictionary containing collected rollout data
         """
         # Reset buffer
         self.rollout_buffer.reset()
-        
+
         # Get initial observation if needed
         if not hasattr(self, '_current_obs'):
             self._current_obs, self._current_info = safe_env_reset(self.env)
             self._episode_reward = 0.0
-        
+
         # Collect rollouts
         for step in range(n_steps):
             obs_tensor = torch.FloatTensor(self._current_obs).unsqueeze(0).to(self.device)
-            
+
             # Get action mask
             if hasattr(self.env, 'get_action_mask'):
                 action_mask = self.env.get_action_mask()
             else:
                 action_mask = np.ones(self.env.action_space.n, dtype=bool)
             action_mask_tensor = torch.BoolTensor(action_mask).unsqueeze(0).to(self.device)
-            
+
             # Get tree structure if available
             tree_structure = self._current_info.get('tree_structure') if isinstance(self._current_info, dict) else None
-            
+
             # Get action from policy
             with torch.no_grad():
                 outputs = self.policy(
@@ -262,7 +262,7 @@ class PPOTrainer:
                     ai_model_representation=ai_model_representation,
                     ai_model_type_idx=ai_model_type_idx
                 )
-                
+
                 # Sample action
                 if 'action_logits' in outputs:
                     dist = Categorical(logits=outputs['action_logits'])
@@ -272,15 +272,15 @@ class PPOTrainer:
                     # Fallback for policies that return actions directly
                     action = outputs.get('action', 0)
                     log_prob = 0.0
-                
+
                 value = outputs['value'].item()
                 action = action.item()
-            
+
             # Step environment
             next_obs, reward, terminated, truncated, info = self.env.step(action)
             done = terminated or truncated
             self._episode_reward += reward
-            
+
             # Store transition
             self.rollout_buffer.add(
                 obs=self._current_obs,
@@ -292,25 +292,25 @@ class PPOTrainer:
                 action_mask=action_mask,
                 tree_structure=tree_structure
             )
-            
+
             # Update current state
             self._current_obs = next_obs
             self._current_info = info
             self.total_timesteps += 1
-            
+
             # Handle episode end
             if done:
                 self.episode_rewards.append(self._episode_reward)
                 self._current_obs, self._current_info = safe_env_reset(self.env)
                 self._episode_reward = 0.0
-        
+
         # Compute returns and advantages
         self.rollout_buffer.compute_returns_and_advantages(
             self.policy, self.gamma, self.gae_lambda, task_trajectories
         )
-        
+
         return self.rollout_buffer.get()
-    
+
     def learn(
         self,
         rollout_data: Dict[str, torch.Tensor],
@@ -320,15 +320,15 @@ class PPOTrainer:
     ) -> Dict[str, float]:
         """
         Train the policy on collected rollout data.
-        
+
         This method handles the learning phase with multiple epochs and mini-batches.
-        
+
         Args:
             rollout_data: Dictionary containing rollout data from collect_rollouts
             task_trajectories: Optional task trajectories for meta-learning
-            ai_model_representation: Optional AI model representation  
+            ai_model_representation: Optional AI model representation
             ai_model_type_idx: Optional AI model type index
-            
+
         Returns:
             Dictionary of training metrics averaged over all epochs and batches
         """
@@ -336,48 +336,48 @@ class PPOTrainer:
         for key, value in rollout_data.items():
             if isinstance(value, torch.Tensor):
                 rollout_data[key] = value.to(self.device)
-        
+
         # Get number of samples
         n_samples = len(rollout_data['observations'])
         if n_samples == 0:
             return {'loss': 0.0, 'policy_loss': 0.0, 'value_loss': 0.0, 'entropy': 0.0}
-        
+
         # Training metrics
         epoch_losses = []
         epoch_policy_losses = []
         epoch_value_losses = []
         epoch_entropies = []
-        
+
         # Prepare indices for shuffling
         indices = np.arange(n_samples)
-        
+
         # Train for n_epochs
         for epoch in range(self.n_epochs):
             # Shuffle data
             np.random.shuffle(indices)
-            
+
             # Mini-batch training
             for start_idx in range(0, n_samples, self.batch_size):
                 batch_indices = indices[start_idx:start_idx + self.batch_size]
-                
+
                 if len(batch_indices) == 0:
                     continue
-                
+
                 # Create mini-batch
                 batch = self._create_minibatch(rollout_data, batch_indices)
-                
+
                 # Prepare additional inputs if provided
                 batch_task_traj = None
                 batch_ai_repr = None
                 batch_ai_type = None
-                
+
                 if task_trajectories is not None:
                     batch_task_traj = task_trajectories.expand(len(batch_indices), -1, -1, -1)
                 if ai_model_representation is not None:
                     batch_ai_repr = ai_model_representation.expand(len(batch_indices), -1)
                 if ai_model_type_idx is not None:
                     batch_ai_type = ai_model_type_idx.expand(len(batch_indices))
-                
+
                 # Perform training step
                 metrics = self._train_step(
                     batch,
@@ -385,16 +385,16 @@ class PPOTrainer:
                     batch_ai_repr,
                     batch_ai_type
                 )
-                
+
                 # Accumulate metrics
                 epoch_losses.append(metrics['loss'])
                 epoch_policy_losses.append(metrics['policy_loss'])
                 epoch_value_losses.append(metrics['value_loss'])
                 epoch_entropies.append(metrics['entropy'])
-        
+
         # Update counter
         self.n_updates += 1
-        
+
         # Return averaged metrics
         return {
             'loss': np.mean(epoch_losses),
@@ -403,7 +403,7 @@ class PPOTrainer:
             'entropy': np.mean(epoch_entropies),
             'n_updates': self.n_updates
         }
-    
+
     def _create_minibatch(
         self,
         rollout_data: Dict[str, Any],
@@ -411,7 +411,7 @@ class PPOTrainer:
     ) -> Dict[str, Any]:
         """Create a mini-batch from rollout data."""
         batch = {}
-        
+
         for key, value in rollout_data.items():
             if key == 'tree_structures':
                 # Handle list of tree structures
@@ -424,9 +424,9 @@ class PPOTrainer:
                     batch[key] = value[indices]
                 except (TypeError, IndexError):
                     batch[key] = [value[i] for i in indices.tolist()]
-        
+
         return batch
-    
+
     def _train_step(
         self,
         batch: Dict[str, torch.Tensor],
@@ -436,13 +436,13 @@ class PPOTrainer:
     ) -> Dict[str, float]:
         """
         Perform a single PPO training step on a mini-batch.
-        
+
         Args:
             batch: Mini-batch data
             task_trajectories_batch: Optional task trajectories
             ai_model_representation_batch: Optional AI model representations
             ai_model_type_idx_batch: Optional AI model type indices
-            
+
         Returns:
             Dictionary of training metrics
         """
@@ -454,7 +454,7 @@ class PPOTrainer:
         returns = batch['returns']
         action_masks = batch['action_masks']
         tree_structures = batch.get('tree_structures')
-        
+
         # Forward pass
         outputs = self.policy(
             obs=observations,
@@ -464,40 +464,40 @@ class PPOTrainer:
             ai_model_representation=ai_model_representation_batch,
             ai_model_type_idx=ai_model_type_idx_batch
         )
-        
+
         # Calculate losses
         dist = Categorical(logits=outputs['action_logits'])
         log_probs = dist.log_prob(actions)
         values = outputs['value'].squeeze(-1)
-        
+
         # PPO policy loss
         ratio = torch.exp(log_probs - old_log_probs)
         surr1 = ratio * advantages
         surr2 = torch.clamp(ratio, 1 - self.clip_epsilon, 1 + self.clip_epsilon) * advantages
         policy_loss = -torch.min(surr1, surr2).mean()
-        
+
         # Value loss
         value_loss = F.mse_loss(values, returns)
-        
+
         # Entropy bonus
         entropy = dist.entropy().mean()
-        
+
         # Total loss
         loss = policy_loss + self.value_coef * value_loss - self.entropy_coef * entropy
-        
+
         # Optimize
         self.optimizer.zero_grad()
         loss.backward()
         torch.nn.utils.clip_grad_norm_(self.policy.parameters(), self.max_grad_norm)
         self.optimizer.step()
-        
+
         return {
             'loss': loss.item(),
             'policy_loss': policy_loss.item(),
             'value_loss': value_loss.item(),
             'entropy': entropy.item()
         }
-    
+
     def train(
         self,
         total_timesteps: int,
@@ -511,10 +511,10 @@ class PPOTrainer:
     ) -> Dict[str, List[float]]:
         """
         Main training loop orchestrating collection and learning.
-        
+
         This is the high-level training method that alternates between
         collecting rollouts and learning from them.
-        
+
         Args:
             total_timesteps: Total number of environment steps to train for
             rollout_length: Number of steps per rollout collection phase
@@ -524,7 +524,7 @@ class PPOTrainer:
             ai_model_representation: Optional fixed AI model representation
             ai_model_type_idx: Optional fixed AI model type index
             callback: Optional callback function called after each update
-            
+
         Returns:
             Dictionary of training history
         """
@@ -537,10 +537,10 @@ class PPOTrainer:
             'value_loss': [],
             'entropy': []
         }
-        
+
         # Calculate number of updates
         n_updates = total_timesteps // rollout_length
-        
+
         # Load from checkpoint if available
         start_timestep = 0
         if self.checkpoint_manager:
@@ -548,15 +548,15 @@ class PPOTrainer:
             if loaded_state:
                 start_timestep = loaded_state.get('total_timesteps', 0)
                 print(f"Resumed training from timestep {start_timestep}")
-        
+
         print(f"Starting PPO training for {total_timesteps} timesteps")
         print(f"Rollout length: {rollout_length}, Batch size: {self.batch_size}")
         print(f"Number of epochs: {self.n_epochs}, Number of updates: {n_updates}")
         print("-" * 50)
-        
+
         # Training loop
         start_time = time.time()
-        
+
         while self.total_timesteps < total_timesteps:
             # Collect rollouts
             rollout_data = self.collect_rollouts(
@@ -565,7 +565,7 @@ class PPOTrainer:
                 ai_model_representation=ai_model_representation,
                 ai_model_type_idx=ai_model_type_idx
             )
-            
+
             # Learn from rollouts
             metrics = self.learn(
                 rollout_data=rollout_data,
@@ -573,7 +573,7 @@ class PPOTrainer:
                 ai_model_representation=ai_model_representation,
                 ai_model_type_idx=ai_model_type_idx
             )
-            
+
             # Update history
             history['timesteps'].append(self.total_timesteps)
             history['mean_reward'].append(np.mean(self.episode_rewards) if self.episode_rewards else 0.0)
@@ -581,12 +581,12 @@ class PPOTrainer:
             history['policy_loss'].append(metrics['policy_loss'])
             history['value_loss'].append(metrics['value_loss'])
             history['entropy'].append(metrics['entropy'])
-            
+
             # Logging
             if self.n_updates % log_interval == 0:
                 elapsed_time = time.time() - start_time
                 fps = (self.total_timesteps - start_timestep) / elapsed_time
-                
+
                 print(f"\nUpdate {self.n_updates}/{n_updates}")
                 print(f"Timesteps: {self.total_timesteps}/{total_timesteps}")
                 print(f"FPS: {fps:.1f}")
@@ -596,24 +596,24 @@ class PPOTrainer:
                 print(f"Value loss: {metrics['value_loss']:.4f}")
                 print(f"Entropy: {metrics['entropy']:.4f}")
                 print("-" * 50)
-            
+
             # Checkpointing
             if self.checkpoint_manager and self.n_updates % save_interval == 0:
                 self.save_checkpoint()
-            
+
             # Callback
             if callback is not None:
                 callback(self, metrics)
-        
+
         print(f"\nTraining completed in {time.time() - start_time:.1f} seconds")
-        
+
         return history
-    
+
     def save_checkpoint(self) -> bool:
         """Save training checkpoint."""
         if not self.checkpoint_manager:
             return False
-        
+
         checkpoint_data = {
             'policy_state_dict': self.policy.state_dict(),
             'optimizer_state_dict': self.optimizer.state_dict(),
@@ -631,28 +631,28 @@ class PPOTrainer:
                 'batch_size': self.batch_size
             }
         }
-        
+
         return self.checkpoint_manager.save_checkpoint(
             checkpoint_data,
             self.total_timesteps,
             {'mean_reward': np.mean(self.episode_rewards) if self.episode_rewards else 0.0}
         )
-    
+
     def load_from_checkpoint(self) -> Optional[Dict]:
         """Load from checkpoint."""
         if not self.checkpoint_manager:
             return None
-        
+
         checkpoint_data = self.checkpoint_manager.load_latest_checkpoint()
         if checkpoint_data:
             self.policy.load_state_dict(checkpoint_data['policy_state_dict'])
             self.optimizer.load_state_dict(checkpoint_data['optimizer_state_dict'])
             self.total_timesteps = checkpoint_data.get('total_timesteps', 0)
             self.n_updates = checkpoint_data.get('n_updates', 0)
-            
+
             if 'episode_rewards' in checkpoint_data:
                 self.episode_rewards = deque(checkpoint_data['episode_rewards'], maxlen=100)
-            
+
             return checkpoint_data
-        
+
         return None

--- a/JanusAI/ml/training/self_play_curriculum.py
+++ b/JanusAI/ml/training/self_play_curriculum.py
@@ -19,10 +19,10 @@ from collections import deque
 from stable_baselines3 import PPO
 from stable_baselines3.common.callbacks import BaseCallback
 
-from JanusAI.ml.agents.task_setter import TaskSetterAgent, TaskSetterConfig
-from JanusAI.ml.training.meta_trainer import MAMLTrainer, MetaLearningConfig
-from JanusAI.physics.data.dynamic_task_distribution import DynamicPhysicsTaskDistribution
-from JanusAI.environments.base.symbolic_env import SymbolicDiscoveryEnv
+from janus_ai.ml.agents.task_setter import TaskSetterAgent, TaskSetterConfig
+from janus_ai.ml.training.meta_trainer import MAMLTrainer, MetaLearningConfig
+from janus_ai.physics.data.dynamic_task_distribution import DynamicPhysicsTaskDistribution
+from janus_ai.environments.base.symbolic_env import SymbolicDiscoveryEnv
 
 
 @dataclass

--- a/JanusAI/physics/algorithms/__init__.py
+++ b/JanusAI/physics/algorithms/__init__.py
@@ -6,11 +6,14 @@ Includes symbolic discovery, reinforcement learning, and model-based approaches.
 """
 
 # Symbolic discovery algorithms
-from .genetic import SymbolicRegressor, GeneticAlgorithm
-from .ace import ACEAlgorithm  # Placeholder for ACE implementation
+from janus_ai.physics.genetic import SymbolicRegressor, GeneticAlgorithm
+
+from janus_ai.physics.ace import ACEAlgorithm  # Placeholder for ACE implementation
+
 
 # Reinforcement learning algorithms
-from .reinforcement import (
+from janus_ai.physics.reinforcement import (
+
     BaseRLAgent, 
     SoftActorCritic, 
     TD3,
@@ -19,13 +22,16 @@ from .reinforcement import (
 )
 
 # Model-based algorithms
-from .model_based import MuZeroAgent, DreamerV2Agent  # Placeholders
+from janus_ai.physics.model_based import MuZeroAgent, DreamerV2Agent  # Placeholders
+
 
 # Hybrid algorithms
-from .hybrid import CEMRLAgent, EvolutionaryRLHybrid
+from janus_ai.physics.hybrid import CEMRLAgent, EvolutionaryRLHybrid
+
 
 # Configuration classes
-from .config import AlgorithmConfig, GeneticConfig, RLConfig
+from janus_ai.physics.config import AlgorithmConfig, GeneticConfig, RLConfig
+
 
 __all__ = [
     # Symbolic discovery

--- a/JanusAI/physics/algorithms/genetic.py
+++ b/JanusAI/physics/algorithms/genetic.py
@@ -110,14 +110,14 @@ def _evaluate_expression_fitness_worker(
         return -1e6
 
 # Import Janus components
-from JanusAI.core.grammar.progressive_grammar import ProgressiveGrammar as BaseGrammar # Updated import
-from JanusAI.core.expressions.expression import Expression, Variable
-from JanusAI.core.expressions.symbolic_math import (
+from janus_ai.core.grammar.progressive_grammar import ProgressiveGrammar as BaseGrammar # Updated import
+from janus_ai.core.expressions.expression import Expression, Variable
+from janus_ai.core.expressions.symbolic_math import (
     evaluate_expression_on_data, 
     get_expression_complexity,
     expression_to_string
 )
-from JanusAI.utils.exceptions import (
+from janus_ai.utils.exceptions import (
     JanusError, 
     GrammarError, 
     DataValidationError,
@@ -126,10 +126,10 @@ from JanusAI.utils.exceptions import (
 )
 
 # Import new modular components
-from JanusAI.core.search.config import GAConfig, ExpressionConfig
-from JanusAI.core.search.stats import StatsTracker, SearchStats, GenerationStats
-from JanusAI.core.search.selection import create_selection_strategy
-from JanusAI.core.search.operators import (
+from janus_ai.core.search.config import GAConfig, ExpressionConfig
+from janus_ai.core.search.stats import StatsTracker, SearchStats, GenerationStats
+from janus_ai.core.search.selection import create_selection_strategy
+from janus_ai.core.search.operators import (
     ExpressionGenerator, 
     create_crossover_operator, 
     create_mutation_operator

--- a/JanusAI/physics/validation/benchmarks.py
+++ b/JanusAI/physics/validation/benchmarks.py
@@ -11,10 +11,10 @@ import numpy as np
 from typing import Dict, List, Any, Optional, Tuple, Callable
 
 # Import necessary components from other modules
-from JanusAI.physics.data.task_distribution import PhysicsTask, PhysicsTaskDistribution
-from JanusAI.physics.validation.known_laws import KnownLawLibrary
-from JanusAI.core.expressions.expression import Expression, Variable
-from JanusAI.core.expressions.symbolic_math import evaluate_expression_on_data, are_expressions_equivalent_sympy
+from janus_ai.physics.data.task_distribution import PhysicsTask, PhysicsTaskDistribution
+from janus_ai.physics.validation.known_laws import KnownLawLibrary
+from janus_ai.core.expressions.expression import Expression, Variable
+from janus_ai.core.expressions.symbolic_math import evaluate_expression_on_data, are_expressions_equivalent_sympy
 
 
 class BenchmarkSuite:

--- a/JanusAI/physics/validation/known_laws.py
+++ b/JanusAI/physics/validation/known_laws.py
@@ -11,8 +11,8 @@ from typing import Dict, List, Any, Optional
 from dataclasses import dataclass, field
 
 # Import Expression and Variable for comparison with discovered laws
-from JanusAI.core.expressions.expression import Expression, Variable
-from JanusAI.core.expressions.symbolic_math import get_variables_from_expression, are_expressions_equivalent_sympy
+from janus_ai.core.expressions.expression import Expression, Variable
+from janus_ai.core.expressions.symbolic_math import get_variables_from_expression, are_expressions_equivalent_sympy
 
 
 @dataclass

--- a/JanusAI/scripts/convert_relative_imports.py
+++ b/JanusAI/scripts/convert_relative_imports.py
@@ -1,0 +1,214 @@
+"""
+A script to find and report on relative imports in the JanusAI project,
+suggesting absolute import paths from the 'janus_ai' package root.
+
+This script can run in dry-run mode (default) or apply changes directly.
+
+Usage:
+    Dry run: python JanusAI/scripts/convert_relative_imports.py
+    Apply changes: python JanusAI/scripts/convert_relative_imports.py --apply
+"""
+
+import os
+import re
+from pathlib import Path
+import argparse # For --apply flag
+
+# The name of the top-level package, as it would be imported.
+PACKAGE_NAME = "janus_ai"
+# The main source directory of the package.
+SOURCE_DIR_NAME = "JanusAI"
+
+def get_absolute_path_from_relative(current_file_path: Path, relative_import: str, project_root: Path) -> str:
+    """
+    Converts a relative import path to an absolute one based on the file's location.
+    This version uses a more robust path resolution logic anchored to the project root.
+
+    Args:
+        current_file_path: The Path object of the file containing the import.
+        relative_import: The relative import string (e.g., '.schemas' or '..core.grammar').
+        project_root: The root directory of the project.
+
+    Returns:
+        The calculated absolute import string, or an error message.
+    """
+    # 1. Determine the number of levels to go up (count the leading dots)
+    level = 0
+    temp_path = relative_import
+    while temp_path.startswith('.'):
+        level += 1
+        temp_path = temp_path[1:] # The part after the dots
+
+    # 2. Start from the directory of the current file, resolved to an absolute path
+    import_base_dir = current_file_path.parent.resolve()
+
+    # 3. Move up the directory tree 'level' times
+    for _ in range(level):
+        import_base_dir = import_base_dir.parent
+
+    # 4. Append the rest of the module path (the part after the dots)
+    # temp_path is like 'schemas' or 'core.grammar'
+    target_module_path_parts = []
+    if temp_path: # Ensure temp_path is not empty (e.g. for 'from . import foo')
+        target_module_path_parts = temp_path.split('.')
+
+    # Construct the absolute file system path to the target module/package directory
+    target_fs_path = import_base_dir.joinpath(*target_module_path_parts)
+
+    # 5. Make the target_fs_path relative to the project_root
+    try:
+        # Resolve target_fs_path to ensure it's canonical before making relative
+        # This path should represent the Python module path from the project root
+        path_from_project_root = target_fs_path.resolve().relative_to(project_root.resolve())
+    except ValueError:
+        # This error means target_fs_path is not under project_root, which is unexpected for valid relative imports.
+        return f"# [ERROR] Resolved path '{target_fs_path.resolve()}' is outside project root '{project_root.resolve()}' for file '{current_file_path}' trying to import '{relative_import}'"
+
+    # 6. Construct the final absolute import string using PACKAGE_NAME
+    # path_from_project_root.parts will be like ('JanusAI', 'core', 'module') or ('tests', 'test_module')
+
+    import_parts = list(path_from_project_root.parts)
+
+    # If the first part of this path is the SOURCE_DIR_NAME, replace it with PACKAGE_NAME
+    # e.g., ('JanusAI', 'core', 'module') -> ('janus_ai', 'core', 'module')
+    if import_parts and import_parts[0] == SOURCE_DIR_NAME:
+        final_module_path_parts = [PACKAGE_NAME] + import_parts[1:]
+    # If the first part is something else (like 'tests'), prepend PACKAGE_NAME
+    # e.g., ('tests', 'test_module') -> ('janus_ai', 'tests', 'test_module')
+    # This assumes tests are also part of the overall 'janus_ai' import namespace.
+    else:
+        final_module_path_parts = [PACKAGE_NAME] + import_parts
+
+    return ".".join(final_module_path_parts)
+
+
+def analyze_file(file_path: Path, project_root: Path, apply_changes: bool = False):
+    """
+    Analyzes a single Python file for relative imports.
+    If apply_changes is True, modifies the file in place.
+    Otherwise, prints proposed changes (dry run).
+    Returns a tuple: (number_of_lines_changed, True if file_was_changed else False)
+    """
+    lines_changed_count = 0
+    file_was_changed = False
+
+    try:
+        with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
+            lines = f.readlines()
+    except Exception as e:
+        if not apply_changes:
+            print(f"--- Could not read file: {file_path} ({e})")
+        return 0, False
+
+    new_lines = []
+    relative_import_regex = re.compile(r"^(from\s+(\.+[a-zA-Z0-9_.]*)\s+import.*)")
+
+    # header_printed_for_this_file can be local to the function call for dry run
+    header_printed_for_this_file = False
+
+    for line_number, line in enumerate(lines):
+        match = relative_import_regex.match(line)
+        if match:
+            original_import_statement = match.group(1).strip()
+            relative_path_str = match.group(2).strip()
+
+            leading_whitespace = line[:match.start()]
+            trailing_content = line[match.end():].rstrip('\n')
+
+            parts = original_import_statement.split("import", 1) # Split only on the first "import"
+            import_part_text = "import" + parts[1]
+
+            absolute_path = get_absolute_path_from_relative(file_path, relative_path_str, project_root)
+
+            if "[ERROR]" not in absolute_path:
+                new_from_part = f"from {absolute_path}"
+                new_import_statement = f"{new_from_part} {import_part_text}"
+                new_line_content = f"{leading_whitespace}{new_import_statement}{trailing_content}\n"
+
+                if new_line_content.strip() != line.strip():
+                    if not apply_changes: # Dry run: print changes
+                        if not header_printed_for_this_file:
+                            print(f"\n--- Analyzing: {file_path} ---")
+                            header_printed_for_this_file = True
+                        print(f"  - {line.strip()}")
+                        print(f"  + {new_line_content.strip()}")
+
+                    new_lines.append(new_line_content)
+                    lines_changed_count += 1
+                    file_was_changed = True
+                else:
+                    new_lines.append(line)
+            else: # Error in path conversion
+                if not apply_changes: # Dry run: print error
+                    if not header_printed_for_this_file:
+                        print(f"\n--- Analyzing: {file_path} ---")
+                        header_printed_for_this_file = True
+                    print(f"  - {line.strip()}")
+                    print(f"  + {absolute_path}")
+                new_lines.append(line) # Keep original line on error
+        else:
+            new_lines.append(line)
+
+    if file_was_changed:
+        if apply_changes:
+            try:
+                with open(file_path, 'w', encoding='utf-8') as f:
+                    f.writelines(new_lines)
+                # print(f"  Modified: {file_path} ({lines_changed_count} lines changed)")
+            except Exception as e:
+                print(f"--- Could not write to file: {file_path} ({e})")
+                return 0, False # Failed to write
+        elif header_printed_for_this_file: # Dry run separator only if header was printed
+            print("-" * (len(str(file_path)) + 20))
+
+    return lines_changed_count, file_was_changed
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert relative imports to absolute imports for JanusAI project.")
+    parser.add_argument("--apply", action="store_true", help="Apply changes directly to files. Default is dry run.")
+    args = parser.parse_args()
+
+    project_root = Path.cwd()
+
+    if not (project_root / SOURCE_DIR_NAME).is_dir():
+        print(f"Error: Source directory '{SOURCE_DIR_NAME}' not found in current directory '{project_root}'.")
+        print("Please run this script from the root of the JanusAI project.")
+        return
+
+    APPLY_CHANGES_MODE = args.apply
+
+    if APPLY_CHANGES_MODE:
+        print(f"Starting CONVERSION of relative imports...")
+    else:
+        print(f"Starting analysis of relative imports (Dry Run)...")
+
+    print(f"Scanning Python files in: {project_root}")
+    print(f"Assuming package name: '{PACKAGE_NAME}' and source directory: '{SOURCE_DIR_NAME}'")
+
+    # Removed static variable reset from main as it's now local to analyze_file for dry run
+
+    total_files_changed_count = 0
+    total_lines_transformed_count = 0
+
+    for root_str, dirs, files in os.walk(project_root):
+        root_path = Path(root_str)
+        dirs[:] = [d for d in dirs if d not in ['.venv', 'venv', '__pycache__', '.git', '.github', 'docs'] and not d.endswith('.egg-info')]
+
+        for file_name in files:
+            if file_name.endswith(".py"):
+                file_path = root_path / file_name
+                lines_transformed, file_updated = analyze_file(file_path, project_root, APPLY_CHANGES_MODE)
+                if file_updated:
+                    total_files_changed_count +=1
+                    total_lines_transformed_count += lines_transformed
+
+    if APPLY_CHANGES_MODE:
+        print("\nConversion complete.")
+        print(f"Total files modified: {total_files_changed_count}")
+        print(f"Total lines modified: {total_lines_transformed_count}")
+    else:
+        print("\nDry run analysis complete.")
+
+if __name__ == "__main__":
+    main()

--- a/JanusAI/scripts/examples/memory_system_usage.py
+++ b/JanusAI/scripts/examples/memory_system_usage.py
@@ -10,19 +10,26 @@ from datetime import datetime
 import logging
 
 # Import Janus components
-from ..memory.dual_memory_system import (
+from janus_ai.memory.dual_memory_system import (
+
     DualMemorySystem, Discovery, IntermediateResult,
     EmbeddingGenerator
 )
-from ..memory.memory_integration import (
+from janus_ai.memory.memory_integration import (
+
     MemoryIntegratedEnv, MemoryAugmentedAgent,
     MemoryReplayBuffer, MemoryMetrics
 )
-from ..ml.training.advanced_ppo_trainer import AdvancedPPOTrainer, PPOConfig
-from ..ml.networks.policy_networks import TransformerPolicy
-from ..environments.symbolic_discovery_env import SymbolicDiscoveryEnv
-from ..grammar.ai_grammar import AIGrammar
-from ..rewards.interpretability_reward import InterpretabilityReward
+from janus_ai.ml.training.advanced_ppo_trainer import AdvancedPPOTrainer, PPOConfig
+
+from janus_ai.ml.networks.policy_networks import TransformerPolicy
+
+from janus_ai.environments.symbolic_discovery_env import SymbolicDiscoveryEnv
+
+from janus_ai.grammar.ai_grammar import AIGrammar
+
+from janus_ai.rewards.interpretability_reward import InterpretabilityReward
+
 
 
 # Configure logging

--- a/JanusAI/scripts/examples/reward_handler_examples.py
+++ b/JanusAI/scripts/examples/reward_handler_examples.py
@@ -11,14 +11,14 @@ import numpy as np
 from typing import Dict, Any
 
 # Import reward components and handler
-from JanusAI.ml.rewards.reward_handler import RewardHandler, AdaptiveRewardHandler
-from JanusAI.ml.rewards.reward_registry import (
+from janus_ai.ml.rewards.reward_handler import RewardHandler, AdaptiveRewardHandler
+from janus_ai.ml.rewards.reward_registry import (
     create_handler_from_preset,
     create_reward_component,
     list_available_rewards
 )
-from JanusAI.ml.rewards.intrinsic_rewards import NoveltyReward, ComplexityReward
-from JanusAI.ml.rewards.interpretability_reward import InterpretabilityReward
+from janus_ai.ml.rewards.intrinsic_rewards import NoveltyReward, ComplexityReward
+from janus_ai.ml.rewards.interpretability_reward import InterpretabilityReward
 
 
 # Example 1: Basic Usage with Direct Components

--- a/JanusAI/scripts/experiments/run_physics_validation.py
+++ b/JanusAI/scripts/experiments/run_physics_validation.py
@@ -28,23 +28,23 @@ from typing import List # Added for type hinting
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
-from JanusAI.core.grammar import ProgressiveGrammar
-from JanusAI.core.expressions.expression import Variable # Variable is in .expression module
-# from JanusAI.ai_interpretability.environments import SymbolicDiscoveryEnv, CurriculumManager # Commented out old CurriculumManager
-from JanusAI.environments.base.symbolic_env import SymbolicDiscoveryEnv # Keep SymbolicDiscoveryEnv, moved to base
-from JanusAI.physics.data.dynamic_task_distribution import DynamicPhysicsTaskDistribution
-from JanusAI.ml.training.self_play_curriculum import SelfPlayCurriculumTrainer, SelfPlayConfig
-from JanusAI.ml.networks.hypothesis_net import HypothesisNet, PPOTrainer # Assuming this is the new location
+from janus_ai.core.grammar import ProgressiveGrammar
+from janus_ai.core.expressions.expression import Variable # Variable is in .expression module
+# from janus_ai.ai_interpretability.environments import SymbolicDiscoveryEnv, CurriculumManager # Commented out old CurriculumManager
+from janus_ai.environments.base.symbolic_env import SymbolicDiscoveryEnv # Keep SymbolicDiscoveryEnv, moved to base
+from janus_ai.physics.data.dynamic_task_distribution import DynamicPhysicsTaskDistribution
+from janus_ai.ml.training.self_play_curriculum import SelfPlayCurriculumTrainer, SelfPlayConfig
+from janus_ai.ml.networks.hypothesis_net import HypothesisNet, PPOTrainer # Assuming this is the new location
 from physics_discovery_extensions import SymbolicRegressor, ConservationDetector # External, leave as is
 from experiment_runner import ( # External or local, leave as is
     ExperimentRunner, ExperimentConfig, ExperimentResult,
     HarmonicOscillatorEnv, PendulumEnv, KeplerEnv
 )
-from JanusAI.utils.visualization.plotting import ExperimentVisualizer # Moved
-from JanusAI.experiments.analysis.statistical_tests import perform_statistical_tests # Moved
+from janus_ai.utils.visualization.plotting import ExperimentVisualizer # Moved
+from janus_ai.experiments.analysis.statistical_tests import perform_statistical_tests # Moved
 from utils import calculate_symbolic_accuracy, _count_operations # Local, leave as is
 from integrated_pipeline import JanusConfig, SyntheticDataParamsConfig, RewardConfig # Local, leave as is
-from JanusAI.utils.general_utils import safe_env_reset # Moved
+from janus_ai.utils.general_utils import safe_env_reset # Moved
 
 logging.basicConfig(
     level=logging.INFO,

--- a/JanusAI/scripts/fix_imports.py
+++ b/JanusAI/scripts/fix_imports.py
@@ -3,14 +3,13 @@
 fix_imports.py - A utility to correct import statements across the JanusAI project.
 
 This script scans all Python files within the project and replaces any old
-'JanusAI' import prefixes with the correct 'janus' prefix. This is necessary
-to resolve ModuleNotFoundError issues after renaming the main package directory.
+'JanusAI' import prefixes with the correct 'janus_ai' prefix. This is necessary
+to align with standard Python packaging practices where the package name in
+pyproject.toml (`janus-ai`) is normalized to `janus_ai` for imports.
 
 Usage:
 1. Run this script from the project root directory:
-   python scripts/fix_imports.py
-2. If the script ran on the 'JanusAI' directory, rename it to 'janus':
-   mv JanusAI janus
+   python JanusAI/scripts/fix_imports.py
 """
 
 import os
@@ -18,34 +17,30 @@ import os
 def fix_imports_in_project():
     """
     Walks through the project, finds all .py files, and corrects
-    'from JanusAI' or 'import JanusAI' to 'from janus' or 'import janus'.
-    This version is more robust and checks for both 'janus' and 'JanusAI' directories.
+    'from janus_ai' or 'import janus_ai' to 'from janus_ai' or 'import janus_ai'.
     """
-    project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    # Assuming the script is in JanusAI/scripts/fix_imports.py
+    # project_root will be the directory containing the JanusAI directory.
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
     
     # --- ENHANCED DIRECTORY CHECKING ---
-    janus_dir = os.path.join(project_root, 'janus')
+    # The source directory is JanusAI, located directly in the project_root
     janusai_dir = os.path.join(project_root, 'JanusAI')
     
     source_dir = None
-    needs_rename = False
     
-    if os.path.isdir(janus_dir):
-        source_dir = janus_dir
-        print("🔍 Found 'janus' directory. Scanning for old imports...")
-    elif os.path.isdir(janusai_dir):
+    if os.path.isdir(janusai_dir):
         source_dir = janusai_dir
-        needs_rename = True
         print("🔍 Found 'JanusAI' directory. Will fix imports inside.")
     else:
-        print(f"❌ Error: Neither 'janus' nor 'JanusAI' source directories found in the project root.")
-        print("   Please ensure you are running this script from the correct location.")
+        print(f"❌ Error: 'JanusAI' source directory not found in the project root.")
+        print("   Please ensure you are running this script from the correct location relative to the 'JanusAI' directory.")
         return
         
-    old_prefix_from = "from JanusAI"
-    new_prefix_from = "from janus"
-    old_prefix_import = "import JanusAI"
-    new_prefix_import = "import janus"
+    old_prefix_from = "from janus_ai"
+    new_prefix_from = "from janus_ai"
+    old_prefix_import = "import janus_ai"
+    new_prefix_import = "import janus_ai"
     
     files_modified = 0
     total_replacements = 0
@@ -67,13 +62,13 @@ def fix_imports_in_project():
                     
                     new_content = content
                     
-                    # Fix 'from JanusAI...' statements
+                    # Fix 'from janus_ai...' statements
                     if old_prefix_from in new_content:
                         count = new_content.count(old_prefix_from)
                         new_content = new_content.replace(old_prefix_from, new_prefix_from)
                         replacements_in_file += count
 
-                    # Fix 'import JanusAI...' statements
+                    # Fix 'import janus_ai...' statements
                     if old_prefix_import in new_content:
                         count = new_content.count(old_prefix_import)
                         new_content = new_content.replace(old_prefix_import, new_prefix_import)
@@ -97,16 +92,7 @@ def fix_imports_in_project():
         print(f"   Total files modified: {files_modified}")
         print(f"   Total imports corrected: {total_replacements}")
     else:
-        print("   No incorrect 'JanusAI' imports were found. Your project is already up to date!")
-    
-    if needs_rename:
-        print("\n" + "!"*70)
-        print("‼️ IMPORTANT NEXT STEP ‼️")
-        print("   The script has fixed the imports inside the 'JanusAI' directory.")
-        print("   You must now rename the directory for the imports to work.")
-        print("   From your project root, please run this command:")
-        print("\n      mv JanusAI janus\n")
-        print("!"*70)
+        print("   No incorrect 'JanusAI' imports were found. Your project might already be using 'janus_ai' or has no 'JanusAI' imports.")
     
     print("="*70)
 

--- a/JanusAI/scripts/train/basic_training.py
+++ b/JanusAI/scripts/train/basic_training.py
@@ -16,9 +16,9 @@ import yaml
 import torch
 import psutil
 from typing import Dict, Any, Optional # Added Optional for save_checkpoint
-from JanusAI.utils.math.operations import validate_inputs, safe_import
-from JanusAI.config.models import JanusConfig # For type hinting
-from JanusAI.config.loader import ConfigLoader # Added ConfigLoader
+from janus_ai.utils.math.operations import validate_inputs, safe_import
+from janus_ai.config.models import JanusConfig # For type hinting
+from janus_ai.config.loader import ConfigLoader # Added ConfigLoader
 
 # Optional imports with fallbacks using safe_import
 ray = safe_import("ray", "ray")

--- a/JanusAI/tests/integration/test_pipelines/test_integrated_pipeline_enhanced.py
+++ b/JanusAI/tests/integration/test_pipelines/test_integrated_pipeline_enhanced.py
@@ -3,9 +3,9 @@ from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 import integrated_pipeline
-from JanusAI.integration.pipeline import AdvancedJanusTrainer, JanusConfig
-from JanusAI.core.grammar import ProgressiveGrammar
-from JanusAI.core.expression import Variable
+from janus_ai.integration.pipeline import AdvancedJanusTrainer, JanusConfig
+from janus_ai.core.grammar import ProgressiveGrammar
+from janus_ai.core.expression import Variable
 
 class DummyEnv:
     def __init__(self, **kwargs):

--- a/JanusAI/tests/test_memory_system.py
+++ b/JanusAI/tests/test_memory_system.py
@@ -13,15 +13,15 @@ from datetime import datetime, timedelta
 import threading
 from pathlib import Path
 
-from ..memory.dual_memory_system import (
+from janus_ai.memory.dual_memory_system import (
     DualMemorySystem, EpisodicMemory, SharedMemory,
     Discovery, IntermediateResult, EmbeddingGenerator
 )
-from ..memory.memory_integration import (
+from janus_ai.memory.memory_integration import (
     MemoryIntegratedEnv, MemoryAugmentedAgent,
     MemoryReplayBuffer, MemoryMetrics
 )
-from ..memory.advanced_features import (
+from janus_ai.memory.advanced_features import (
     MemoryConsolidator, MemoryVisualizer,
     MemoryExporter, ImportanceSampler
 )

--- a/JanusAI/tests/unit/ai_interpretability/evaluation/test_consistency.py
+++ b/JanusAI/tests/unit/ai_interpretability/evaluation/test_consistency.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 from typing import Any, Dict, List, Optional, Union
 from dataclasses import dataclass, field
 
-# Mock dependencies from JanusAI.core and JanusAI.utils
+# Mock dependencies from janus_ai.core and JanusAI.utils
 # These mocks are based on the ones in the __main__ block of consistency.py
 @dataclass(eq=True, frozen=False)
 class MockVariable:

--- a/JanusAI/tests/unit/ai_interpretability/evaluation/test_fidelity.py
+++ b/JanusAI/tests/unit/ai_interpretability/evaluation/test_fidelity.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 import sympy as sp
 from unittest.mock import MagicMock, patch
 
-from JanusAI.ai_interpretability.evaluation.fidelity import FidelityCalculator
+from janus_ai.ai_interpretability.evaluation.fidelity import FidelityCalculator
 
 # --- Helper Mocks ---
 @pytest.fixture

--- a/JanusAI/tests/unit/experiments/runner/test_base_runner.py
+++ b/JanusAI/tests/unit/experiments/runner/test_base_runner.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch, ANY
 import numpy as np
 import torch
 
-from JanusAI.experiments.runner.base_runner import BaseExperimentRunner
+from janus_ai.experiments.runner.base_runner import BaseExperimentRunner
 
 # --- Mocks for dependencies ---
 MockSymbolicDiscoveryEnv = MagicMock(name="MockSymbolicDiscoveryEnv")

--- a/JanusAI/utils/config/test_validation.py
+++ b/JanusAI/utils/config/test_validation.py
@@ -8,7 +8,7 @@ import pytest
 from typing import List, Dict, Optional, Union, Any
 import numpy as np
 
-from JanusAI.utils.config.validation import validate_inputs
+from janus_ai.utils.config.validation import validate_inputs
 
 
 class TestValidateInputsDecorator:

--- a/JanusAI/utils/config/validation.py
+++ b/JanusAI/utils/config/validation.py
@@ -12,7 +12,7 @@ from typing import Dict, List, Optional, Any, Union
 import logging
 from dataclasses import fields
 
-from JanusAI.config.models import JanusConfig
+from janus_ai.config.models import JanusConfig
 
 
 class StrictModeValidator:

--- a/JanusAI/utils/evaluation/model_fidelity.py
+++ b/JanusAI/utils/evaluation/model_fidelity.py
@@ -14,8 +14,8 @@ import sympy as sp
 from typing import Any, Callable, Dict, List, Optional, Union
 
 # Import components from new structure
-from JanusAI.core.expressions.expression import Expression, Variable # For type hinting expression
-from JanusAI.core.expressions.symbolic_math import evaluate_expression_on_data # For evaluating symbolic expressions
+from janus_ai.core.expressions.expression import Expression, Variable # For type hinting expression
+from janus_ai.core.expressions.symbolic_math import evaluate_expression_on_data # For evaluating symbolic expressions
 
 # Placeholder for AI model classes, assuming they are nn.Module compatible
 try:

--- a/JanusAI/utils/logging/wandb_integration.py
+++ b/JanusAI/utils/logging/wandb_integration.py
@@ -7,7 +7,7 @@ for experiment tracking, visualization, and collaboration.
 """
 
 # Use safe_import to make wandb an optional dependency
-from JanusAI.utils.general_utils import safe_import
+from janus_ai.utils.general_utils import safe_import
 wandb = safe_import("wandb", "wandb")
 
 from typing import Any, Dict, Optional, Union, List

--- a/JanusAI/utils/registry.py
+++ b/JanusAI/utils/registry.py
@@ -16,9 +16,9 @@ from dataclasses import dataclass, field
 from abc import ABC, abstractmethod
 import yaml
 
-from JanusAI.experiments.base import BaseExperiment
-from JanusAI.config.models import ExperimentConfig
-from JanusAI.utils.exceptions import ExperimentNotFoundError, InvalidExperimentError
+from janus_ai.experiments.base import BaseExperiment
+from janus_ai.config.models import ExperimentConfig
+from janus_ai.utils.exceptions import ExperimentNotFoundError, InvalidExperimentError
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
- Modified and used a script to convert 'from JanusAI...' imports to 'from janus_ai...'.
- Modified and used a script to convert relative imports ('.', '..') to absolute 'janus_ai...' imports.
- Some test failures remain that are unrelated to import errors and will be addressed separately.

## Summary by Sourcery

Refactor the entire codebase to use consistent absolute imports rooted at the `janus_ai` package rather than `JanusAI` or relative paths, and introduce helper scripts to automate import fixes.

Enhancements:
- Replace all `from JanusAI...` and `import JanusAI...` statements with `from janus_ai...` absolute imports across modules
- Convert relative imports (leading `.`) in Python files to their absolute `janus_ai...` paths
- Add `convert_relative_imports.py` to analyze and optionally apply relative-to-absolute import transformations
- Update `fix_imports.py` to robustly detect the project structure and correct import prefixes to `janus_ai`