### PR TITLE
Fix: Implement robust expression string parsing

### DIFF
--- a/JanusAI/experiments/runner/distributed_runner.py
+++ b/JanusAI/experiments/runner/distributed_runner.py
@@ -117,14 +117,15 @@ class AsyncExpressionEvaluator:
                 self.cache.popitem(last=False)
 
             try:
-                # Parse expression
-                # create_expression will validate by default and return None if invalid
-                expr = self.grammar.create_expression('var', [expr_str]) 
+                # Parse expression string into a Janus Expression object
+                # This uses the new method in ProgressiveGrammar (and AIGrammar if inherited)
+                expr = self.grammar.parse_expression_string(expr_str)
                 
                 if expr is None:
-                    # Log the error for debugging (assuming logger is set up)
-                    # print(f"Validation failed for expression string: {expr_str}")
-                    raise ValueError(f"Expression validation failed for: {expr_str}")
+                    # This means parsing or subsequent validation within create_expression failed.
+                    # Logging for this is handled within parse_expression_string or _convert_sympy_to_janus_expression.
+                    # print(f"Failed to parse or validate expression string: {expr_str}")
+                    raise ValueError(f"Failed to parse or validate expression: '{expr_str}'")
 
                 # Evaluate on data
                 predictions = []


### PR DESCRIPTION
Previously, AsyncExpressionEvaluator incorrectly wrapped expression strings as 'var' type Expressions, leading to failed symbolic evaluations.

This commit introduces a proper parsing mechanism in ProgressiveGrammar:
1. Added `_convert_sympy_to_janus_expression` to recursively convert a SymPy expression tree to a Janus Expression tree, mapping SymPy constructs (symbols, numbers, functions like Add, Mul, sin, Derivative) to their Janus counterparts.
2. Added `parse_expression_string` to ProgressiveGrammar, which uses `symbolic_math.create_sympy_expression` to parse a string to SymPy, then uses the new conversion helper to get a Janus Expression.
3. Modified `AsyncExpressionEvaluator.evaluate_batch` to use `grammar.parse_expression_string` for correct parsing.

This ensures that expression strings are transformed into the appropriate Janus Expression object structure, enabling correct symbolic manipulation and evaluation.